### PR TITLE
cmake: linking app with runtime library together with rust app library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,15 @@ ${config_paths}
         kobj_types_h_target
   )
 
-  target_link_libraries(app PUBLIC -Wl,--allow-multiple-definition ${RUST_LIBRARY})
+  # Linking with the <rt_library> (`$<TARGET_PROPERTY:linker,rt_library>`).
+  # -lgcc / -lcompiler_rt depending on toolchain, linker, and runtime library configuration.
+  # In general this shouldn't be needed, as the runtime libary is generally linked late, but
+  # librustapp.a includes it's own runtime functions, and on riscv (and potentially others) an
+  # unrecognized / unknown type is used in the relocation section for clzsi2 object.
+  # Thus we must for current time ensure that the runtime library is before librustapp.a.
+  # Example of warning reported by ld when this fix is not in place:
+  # <path>/ld.bfd: rust/target/riscv64imac-unknown-none-elf/debug/librustapp.a(45c91108d938afe8-clzdi2.o): unsupported relocation type 0x3d
+  target_link_libraries(app PUBLIC $<TARGET_PROPERTY:linker,rt_library> -Wl,--allow-multiple-definition ${RUST_LIBRARY})
   add_dependencies(app librustapp)
 
   # Presumably, Rust applications will have no C source files, but cmake will require them.


### PR DESCRIPTION
The Zephyr PR https://github.com/zephyrproject-rtos/zephyr/pull/78320 clean up and improves link handling in Zephyr.

One improvement is the deterministic and correct link location of runtime and C library linking at the end of link arguments to ensure all libraries are able to use standard functions.

However the librustapp.a library created by the cargo tool also contains runtime functions. It would in most cases be considered correct that a library, such as librustapp.a, which provides functions are linked first so that those functions provided as part of rust toolchain takes precedence over the runtime library provided by the C / C++ toolchain.

However on the riscv32 / riscv64 architecture the rust prebuilt libraries makes use of relocation types in the clzsi2 object which are unknown to the ld linker in use.
Thus linking librustapp.a first, for example like `librustapp.a -lgcc` results in the following warning (and thus CI failures):
```
<path>/ld.bfd: <path>/librustapp.a(45c91108d938afe8-clzdi2.o): unsupported relocation type 0x3d
```

Therefore we ensure that the runtime library is linked first, for example `-lgcc librustapp.a`.