### PR TITLE
Fixes to Thread

### DIFF
--- a/zephyr/src/sys/thread.rs
+++ b/zephyr/src/sys/thread.rs
@@ -423,7 +423,7 @@ impl StaticThread {
     #[cfg(CONFIG_RUST_ALLOC)]
     /// Spawn a thread, running a closure.  The closure will be boxed to give to the new thread.
     /// The new thread runs immediately.
-    pub fn spawn<F: FnOnce() + Send + 'static>(&self, stack: StackToken, child: F) -> Thread {
+    pub fn spawn<F: FnOnce() + Send + 'static>(self, stack: StackToken, child: F) -> Thread {
         let child: closure::Closure = Box::new(child);
         let child = Box::into_raw(Box::new(closure::ThreadData {
             closure: ManuallyDrop::new(child),


### PR DESCRIPTION
Two things here:  One is an important fix to `Thread::spawn` which makes it safe against multiple spawns of the same thread.

The other is to add a method to set the name of the thread.