### PR TITLE
cmake: Avoid appearing to support targets with dynamic timers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,11 @@ on:
   push:
     branches:
       - main
+      - v*-branch
   pull_request:
     branches:
       - main
+      - v*-branch
   schedule:
     - cron: "0 0 * * *"
 

--- a/Kconfig
+++ b/Kconfig
@@ -7,8 +7,9 @@ menu "Rust Language Support"
 
 config RUST_SUPPORTED
 	bool
-	default y if (CPU_CORTEX_M || \
-		(RISCV && !RISCV_ISA_RV32E && !RISCV_ISA_RV128I))
+	default y if ((CPU_CORTEX_M || \
+				(RISCV && !RISCV_ISA_RV32E && !RISCV_ISA_RV128I)) && \
+				!TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
 	help
 	  Selected for platforms that have support for Rust.
 

--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -9,6 +9,14 @@ common:
       - "Hello world from Rust on (.*)"
   tags: rust
   filter: CONFIG_RUST_SUPPORTED
+  platform_allow:
+    - qemu_cortex_m0
+    - qemu_cortex_m3
+    - qemu_riscv32
+    - qemu_riscv32/qemu_virt_riscv32/smp
+    - qemu_riscv64
+    - qemu_riscv64/qemu_virt_riscv64/smp
+    - nrf52840dk/nrf52840
 tests:
   sample.rust.helloworld:
     tags: introduction

--- a/tests/time/testcase.yaml
+++ b/tests/time/testcase.yaml
@@ -1,5 +1,13 @@
 common:
   filter: CONFIG_RUST_SUPPORTED
+  platform_allow:
+    - qemu_cortex_m0
+    - qemu_cortex_m3
+    - qemu_riscv32
+    - qemu_riscv32/qemu_virt_riscv32/smp
+    - qemu_riscv64
+    - qemu_riscv64/qemu_virt_riscv64/smp
+    - nrf52840dk/nrf52840
 tests:
   test.rust.time:
     harness: console


### PR DESCRIPTION
The code conditionally compiles against building on systems with dynami timers.  Until this support can be added, be sure to not define `RUST_SUPPORTED` on these targets.