### PR TITLE
Create some log handlers between Rust and the Zephyr world

### DIFF
--- a/main.c
+++ b/main.c
@@ -10,10 +10,36 @@
 
 extern void rust_main(void);
 
+// Logging, to see how things things are expanded.
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(rust, 3);
+
 int main(void)
 {
 	rust_main();
 	return 0;
+}
+
+void rust_log_message(uint32_t level, char *msg) {
+	// Ok.  The log macros in Zephyr perform all kinds of macro stitching, etc, on the
+	// arguments.  As such, we can't just pass the level to something, but actually need to
+	// expand things here.  This puts the file and line information of the log in this file,
+	// rather than where we came from.
+	switch (level) {
+	case LOG_LEVEL_ERR:
+		LOG_ERR("%s", msg);
+		break;
+	case LOG_LEVEL_WRN:
+		LOG_WRN("%s", msg);
+		break;
+	case LOG_LEVEL_INF:
+		LOG_INF("%s", msg);
+		break;
+	case LOG_LEVEL_DBG:
+	default:
+		LOG_DBG("%s", msg);
+		break;
+	}
 }
 
 /* On most arches, panic is entirely macros resulting in some kind of inline assembly.  Create this

--- a/main.c
+++ b/main.c
@@ -10,15 +10,10 @@
 
 extern void rust_main(void);
 
+#if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MINIMAL)
 // Logging, to see how things things are expanded.
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(rust, 3);
-
-int main(void)
-{
-	rust_main();
-	return 0;
-}
 
 void rust_log_message(uint32_t level, char *msg) {
 	// Ok.  The log macros in Zephyr perform all kinds of macro stitching, etc, on the
@@ -40,6 +35,13 @@ void rust_log_message(uint32_t level, char *msg) {
 		LOG_DBG("%s", msg);
 		break;
 	}
+}
+#endif /* defined(CONFIG_LOG) && !defined(CONFIG_LOG_MINIMAL) */
+
+int main(void)
+{
+	rust_main();
+	return 0;
 }
 
 /* On most arches, panic is entirely macros resulting in some kind of inline assembly.  Create this

--- a/samples/hello_world/Cargo.toml
+++ b/samples/hello_world/Cargo.toml
@@ -14,3 +14,4 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = "3.7.0"
+log = "0.4.22"

--- a/samples/hello_world/prj.conf
+++ b/samples/hello_world/prj.conf
@@ -1,7 +1,12 @@
 # Copyright (c) 2024 Linaro LTD
 # SPDX-License-Identifier: Apache-2.0
 
+# The default 1k stack isn't large enough for rust string formatting with logging.
+CONFIG_MAIN_STACK_SIZE=4096
+
 CONFIG_RUST=y
 
-# CONFIG_RUST_ALLOC=y
-# CONFIG_LOG=y
+CONFIG_RUST_ALLOC=y
+CONFIG_LOG=y
+
+CONFIG_LOG_BACKEND_RTT=n

--- a/samples/hello_world/prj.conf
+++ b/samples/hello_world/prj.conf
@@ -2,3 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_RUST=y
+
+# CONFIG_RUST_ALLOC=y
+# CONFIG_LOG=y

--- a/samples/hello_world/src/lib.rs
+++ b/samples/hello_world/src/lib.rs
@@ -3,14 +3,11 @@
 
 #![no_std]
 
-use zephyr::printkln;
-
-// Reference the Zephyr crate so that the panic handler gets used.  This is only needed if no
-// symbols from the crate are directly used.
-extern crate zephyr;
+use log::info;
 
 #[no_mangle]
 extern "C" fn rust_main() {
-    printkln!("Hello world from Rust on {}",
-              zephyr::kconfig::CONFIG_BOARD);
+    unsafe { zephyr::set_logger().unwrap(); }
+
+    info!("Hello world from Rust on {}", zephyr::kconfig::CONFIG_BOARD);
 }

--- a/zephyr-sys/build.rs
+++ b/zephyr-sys/build.rs
@@ -71,9 +71,11 @@ fn main() -> Result<()> {
         .allowlist_function("k_.*")
         .allowlist_function("gpio_.*")
         .allowlist_function("sys_.*")
+        .allowlist_function("z_log.*")
         .allowlist_item("E.*")
         .allowlist_item("K_.*")
         .allowlist_item("ZR_.*")
+        .allowlist_item("LOG_LEVEL_.*")
         // Deprecated
         .blocklist_function("sys_clock_timeout_end_calc")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/zephyr-sys/wrapper.h
+++ b/zephyr-sys/wrapper.h
@@ -33,6 +33,7 @@ extern int errno;
 #include <zephyr/kernel.h>
 #include <zephyr/kernel/thread_stack.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
 
 /*
  * bindgen will output #defined constant that resolve to simple numbers.  There are some symbols

--- a/zephyr/Cargo.toml
+++ b/zephyr/Cargo.toml
@@ -15,6 +15,12 @@ zephyr-sys = { version = "3.7.0", path = "../zephyr-sys" }
 # Although paste is brought in, it is a compile-time macro, and is not linked into the application.
 paste = "1.0"
 
+# cfg-if is a compile-time macro as well, to make conditional compilation a bit easier to write.
+cfg-if = "1.0"
+
+# The log create is used if the user desires logging, and calls `set_logger()`.
+log = "0.4.22"
+
 [dependencies.fugit]
 version = "0.3.7"
 

--- a/zephyr/src/lib.rs
+++ b/zephyr/src/lib.rs
@@ -12,12 +12,15 @@
 
 pub mod align;
 pub mod error;
+pub mod logging;
 pub mod object;
 pub mod sync;
 pub mod sys;
 pub mod time;
 
 pub use error::{Error, Result};
+
+pub use logging::set_logger;
 
 /// Re-exported for local macro use.
 pub use paste::paste;

--- a/zephyr/src/logging.rs
+++ b/zephyr/src/logging.rs
@@ -41,7 +41,8 @@ cfg_if::cfg_if! {
     {
         // Otherwise, if we have logging and allocation, and not minimal, we can use the Zephyr
         // logging backend.  Doing this without allocation is currently a TODO:
-        todo!("Zephyr logging not yet supported");
+        mod impl_zlog;
+        pub use impl_zlog::set_logger;
     } else {
         /// No lagging is possible, provide an empty handler that does nothing.
         ///

--- a/zephyr/src/logging.rs
+++ b/zephyr/src/logging.rs
@@ -1,0 +1,76 @@
+//! Rust logging in Zephyr
+//!
+//! There are a few config settings in Zephyr that affect how logging is done.  Zephyr has multiple
+//! choices of front ends and backends for the logging.  We try to work with a few of these.
+//!
+//! There are various tradeoffs in terms of code size, and processing time that affect how logging
+//! is done.  In addition to the tradeoffs in Zephyr, there are also tradeoffs in the Rust world,
+//! especially when it comes to formatting.
+//!
+//! For now, any use of logging in Rust will go through the `log` crate.  This brings in the
+//! overhead of string formatting.  For the most part, due to a semantic mismatch between how Rust
+//! does string formatting, and how C does it, we will not defer logging, but generate log strings
+//! that will be sent as full strings to the Zephyr logging system.
+//!
+//! - `CONFIG_LOG`: Global enable of logging in Zephyr.
+//! - `CONFIG_LOG_MODE_MINIMAL`: Indicates a minimal printk type of logging.
+//!
+//! At this time, we will provide two loggers.  One is based on using the underlying printk
+//! mechanism, and if enabled, will send log messages directly to printk.  This roughly corresponds
+//! to the minimal logging mode of Zephyr, but also works if logging is entirely disabled.
+//!
+//! The other log backend uses the logging infrastructure to log simple messages to the C logger.
+//! At this time, these require allocation for the string formatting, although the allocation will
+//! generally be short lived.  A good future task will be to make the string formatter format
+//! directly into the log buffer used by Zephyr.
+
+use log::{LevelFilter, Log, SetLoggerError};
+
+cfg_if::cfg_if! {
+    if #[cfg(all(CONFIG_PRINTK,
+                 any(not(CONFIG_LOG),
+                     all(CONFIG_LOG, CONFIG_LOG_MODE_MINIMAL))))]
+    {
+        // If we either have no logging, or it is minimal, and we have printk, we can do the printk
+        // logging handler.
+        mod impl_printk;
+        pub use impl_printk::set_logger;
+    } else if #[cfg(all(CONFIG_LOG,
+                        not(CONFIG_LOG_MODE_MINIMAL),
+                        CONFIG_RUST_ALLOC))]
+    {
+        // Otherwise, if we have logging and allocation, and not minimal, we can use the Zephyr
+        // logging backend.  Doing this without allocation is currently a TODO:
+        todo!("Zephyr logging not yet supported");
+    } else {
+        /// No lagging is possible, provide an empty handler that does nothing.
+        ///
+        /// It could be nice to print a message somewhere, but this is only available when there is
+        /// no where we can send messages.
+        pub unsafe fn set_logger() -> Result<(), SetLoggerError> {
+            Ok(())
+        }
+    }
+}
+
+// The Rust logging system has different entry points based on whether or not we are on a target
+// with atomic pointers.  We will provide a single function for this, which will be safe or unsafe
+// depending on this.  The safety has to do with initialization order, and as long as this is called
+// before any other threads run, it should be safe.
+//
+// TODO: Allow the default level to be set through Kconfig.
+cfg_if::cfg_if! {
+    if #[cfg(target_has_atomic = "ptr")] {
+        unsafe fn set_logger_internal(logger: &'static dyn Log) -> Result<(), SetLoggerError> {
+            log::set_logger(logger)?;
+            log::set_max_level(LevelFilter::Info);
+            Ok(())
+        }
+    } else {
+        unsafe fn set_logger_internal(logger: &'static dyn Log) -> Result<(), SetLoggerError> {
+            log::set_logger_racy(logger)?;
+            log::set_max_level_racy(LevelFilter::Info);
+            Ok(())
+        }
+    }
+}

--- a/zephyr/src/logging/impl_printk.rs
+++ b/zephyr/src/logging/impl_printk.rs
@@ -1,0 +1,46 @@
+//! Logging through printk
+//!
+//! This module implements a log handler (for the [`log`] crate) that logs messages through Zephyr's
+//! printk mechanism.
+//!
+//! Currently, filtering is global, and set to Info.
+
+use log::{Log, Metadata, Record, SetLoggerError};
+
+use crate::printkln;
+
+/// A simple log handler, built around printk.
+struct PrintkLogger;
+
+impl Log for PrintkLogger {
+    // For now, everything is just available.
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    // Print out the log message, using printkln.
+    //
+    // Normal caveats behind printkln apply, if `RUST_PRINTK_SYNC` is not defined, then all message
+    // printing will be racy.  Otherwise, the message will be broken into small chunks that are each
+    // printed atomically.
+    fn log(&self, record: &Record<'_>) {
+        printkln!("{}:{}: {}",
+                  record.level(),
+                  record.target(),
+                  record.args());
+    }
+
+    // Flush is not needed.
+    fn flush(&self) {
+    }
+}
+
+static PRINTK_LOGGER: PrintkLogger = PrintkLogger;
+
+/// Set the log handler to log messages through printk in Zephyr.
+///
+/// This is unsafe due to racy issues in the log framework on targets that do not support atomic
+/// pointers.
+pub unsafe fn set_logger() -> Result<(), SetLoggerError> {
+    super::set_logger_internal(&PRINTK_LOGGER)
+}

--- a/zephyr/src/logging/impl_zlog.rs
+++ b/zephyr/src/logging/impl_zlog.rs
@@ -1,0 +1,66 @@
+//! Logging through Zephyr's log mechanism.
+//!
+//! This module implements a log handler for the [`log`] crate that logs messages through Zephyr's
+//! logging infrastructure.
+//!
+//! Zephyr's logging is heavily built around a lot of C assumptions, and involves a lot of macros.
+//! As such, this initial implemention will try to keep things simple, and format the message to an
+//! allocated string, and send that off to the logging infrastructure, formatted as a "%s" message.
+//! There are a lot of opportunities to improve this.
+
+extern crate alloc;
+
+use alloc::format;
+use core::ffi::c_char;
+
+use log::{Level, Log, Metadata, Record, SetLoggerError};
+
+use crate::raw;
+
+struct ZlogLogger;
+
+impl Log for ZlogLogger {
+    // For now, just always print messages.
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    /// Print out the log message.
+    fn log(&self, record: &Record<'_>) {
+        let level = match record.level() {
+            Level::Error => raw::LOG_LEVEL_ERR,
+            Level::Warn => raw::LOG_LEVEL_WRN,
+            Level::Info => raw::LOG_LEVEL_INF,
+            Level::Debug => raw::LOG_LEVEL_DBG,
+            // Zephyr doesn't have a separate trace, so fold that into debug.
+            Level::Trace => raw::LOG_LEVEL_DBG,
+        };
+        let mut msg = format!("{}: {}",
+                              record.target(),
+                              record.args());
+        // Append a null so this is a valid C string.  This lets us avoid an additional allocation
+        // and copying.
+        msg.push('\x00');
+        unsafe {
+            rust_log_message(level, msg.as_ptr() as *const c_char);
+        }
+    }
+
+    // Flush not needed.
+    fn flush(&self) {
+    }
+}
+
+extern "C" {
+    fn rust_log_message(level: u32, msg: *const c_char);
+}
+
+static ZLOG_LOGGER: ZlogLogger = ZlogLogger;
+
+/// Set the log handler to log messages through Zephyr's logging framework.
+///
+/// This is unsafe due to racy issues in the log framework on targets that do not support atomic
+/// pointers.
+pub unsafe fn set_logger() -> Result<(), SetLoggerError> {
+    super::set_logger_internal(&ZLOG_LOGGER)
+}

--- a/zephyr/src/sys/queue.rs
+++ b/zephyr/src/sys/queue.rs
@@ -6,6 +6,7 @@
 
 use core::ffi::c_void;
 use core::fmt;
+#[cfg(CONFIG_RUST_ALLOC)]
 use core::mem;
 
 use zephyr_sys::{
@@ -15,6 +16,7 @@ use zephyr_sys::{
     k_queue_get,
 };
 
+#[cfg(CONFIG_RUST_ALLOC)]
 use crate::error::Result;
 use crate::sys::K_FOREVER;
 use crate::object::{Fixed, StaticKernelObject, Wrapped};

--- a/zephyr/src/sys/sync/mutex.rs
+++ b/zephyr/src/sys/sync/mutex.rs
@@ -9,6 +9,7 @@
 //! [`object`]: crate::object
 
 use core::fmt;
+#[cfg(CONFIG_RUST_ALLOC)]
 use core::mem;
 use crate::{
     error::{Result, to_result_void},

--- a/zephyr/src/sys/sync/semaphore.rs
+++ b/zephyr/src/sys/sync/semaphore.rs
@@ -13,6 +13,7 @@
 
 use core::ffi::c_uint;
 use core::fmt;
+#[cfg(CONFIG_RUST_ALLOC)]
 use core::mem;
 
 use crate::{


### PR DESCRIPTION
This implements three simplistic log handlers when running on top of Zephyr. All of these are built around the string formatting `log` crate, and as such will have a noticeable impact on code size, as well as stack usage for any thread that is logging.

The three handlers are:
  - none: Messages logged through `log::info!()` and friends are discarded.
  - printk: Messages are logged directly through the printk mechanism.  This is selected if either `CONFIG_LOG` is disabled or if `CONFIG_LOG_MODE_MINIMAL` is selected.
  - zlog: Logs messages through Zephyr's logging framework. Rather than trying to decipher the maze of twisty macros of Zephyr's logging, this logs into an allocated string, and submits the message via Zephyr's regular log macros.

Think of this as more of a stop-gap to get some kind of logging working. Better integration will probably require work on both the Zephyr C code as well as here.