### PR TITLE
Implement Bounded channels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,6 @@ jobs:
           lscpu
           df -h
 
-          west twister -M all -T samples -T tests -v --inline-logs --integration -j 4 \
+          ../zephyr/scripts/twister -M all -T samples -T tests -v --inline-logs --integration -j 4 \
              --timeout-multiplier 2 \
              $(cat etc/platforms.txt)

--- a/samples/philosophers/Kconfig
+++ b/samples/philosophers/Kconfig
@@ -40,3 +40,12 @@ choice
 		  channels to synchronize.
 
 endchoice
+
+if SYNC_CHANNEL
+	config USE_BOUNDED_CHANNELS
+	bool "Should channel sync use dounded channels?"
+	default y
+	help
+	  If set, the channel-based communication will use bounded channels with bounds calculated
+	  to not ever block.
+endif

--- a/samples/philosophers/Kconfig
+++ b/samples/philosophers/Kconfig
@@ -43,7 +43,7 @@ endchoice
 
 if SYNC_CHANNEL
 	config USE_BOUNDED_CHANNELS
-	bool "Should channel sync use dounded channels?"
+	bool "Should channel sync use bounded channels?"
 	default y
 	help
 	  If set, the channel-based communication will use bounded channels with bounds calculated

--- a/samples/philosophers/sample.yaml
+++ b/samples/philosophers/sample.yaml
@@ -32,8 +32,15 @@ tests:
     min_ram: 32
     extra_configs:
       - CONFIG_SYNC_CONDVAR=y
-  sample.rust.philosopher.channel:
+  sample.rust.philosopher.channel_bounded:
     tags: introduction
     min_ram: 32
     extra_configs:
       - CONFIG_SYNC_CHANNEL=y
+      - CONFIG_USE_BOUNDED_CHANNELS=y
+  sample.rust.philosopher.channel_unbounded:
+    tags: introduction
+    min_ram: 32
+    extra_configs:
+      - CONFIG_SYNC_CHANNEL=y
+      - CONFIG_USE_BOUNDED_CHANNELS=n

--- a/zephyr/src/sync/channel.rs
+++ b/zephyr/src/sync/channel.rs
@@ -103,7 +103,7 @@ pub fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
 /// with a capacity of zero.
 pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
     if cap == 0 {
-        panic!("Zero capacity queues no supported on Zephyr");
+        panic!("Zero capacity queues are not supported on Zephyr");
     }
 
     let (s, r) = counter::new(Bounded::new(cap));

--- a/zephyr/src/sync/channel.rs
+++ b/zephyr/src/sync/channel.rs
@@ -10,6 +10,18 @@
 //! In other words, `zephyr::sys::Queue` is a Rust friendly implementation of `k_queue` in Zephyr.
 //! This module provides `Sender` and `Receiver`, which can be cloned and behave as if they had an
 //! internal `Arc` inside them, but without the overhead of an actual Arc.
+//!
+//! ## IRQ safety
+//!
+//! These channels are usable from IRQ context on Zephyr in very limited situations.  Notably, all
+//! of the following must be true:
+//! - The channel has been created with `bounded()`, which pre-allocates all of the messages.
+//! - If the type `T` has a Drop implementation, this implementation can be called from IRQ context.
+//! - Only `try_send` or `try_recv` are used on the channel.
+//!
+//! The requirement for Drop is only strictly true if the IRQ handler calls `try_recv` and drops
+//! received message.  If the message is *always* sent over another channel or otherwise not
+//! dropped, it *might* be safe to use these messages.
 
 extern crate alloc;
 

--- a/zephyr/src/sync/channel.rs
+++ b/zephyr/src/sync/channel.rs
@@ -22,6 +22,7 @@ use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 
 use crate::sys::queue::Queue;
+use crate::time::Forever;
 
 mod counter;
 
@@ -130,7 +131,7 @@ impl<T> Sender<T> {
             }
             SenderFlavor::Bounded(chan) => {
                 // Retrieve a message buffer from the free list.
-                let buf = unsafe { chan.free.recv() };
+                let buf = unsafe { chan.free.recv(Forever) };
                 let buf = buf as *mut Message<T>;
                 unsafe {
                     buf.write(Message::new(msg));
@@ -217,7 +218,7 @@ impl<T> Receiver<T> {
         match &self.flavor {
             ReceiverFlavor::Unbounded { queue, .. } => {
                 let msg = unsafe {
-                    queue.recv()
+                    queue.recv(Forever)
                 };
                 let msg = msg as *mut Message<T>;
                 let msg = unsafe { Box::from_raw(msg) };
@@ -225,7 +226,7 @@ impl<T> Receiver<T> {
             }
             ReceiverFlavor::Bounded(chan) => {
                 let rawbuf = unsafe {
-                    chan.chan.recv()
+                    chan.chan.recv(Forever)
                 };
                 let buf = rawbuf as *mut Message<T>;
                 let msg: Message<T> = unsafe { buf.read() };

--- a/zephyr/src/sync/channel.rs
+++ b/zephyr/src/sync/channel.rs
@@ -404,9 +404,9 @@ impl<T> Bounded<T> {
         let chan = Queue::new().unwrap();
 
         // Add each of the boxes to the free list.
-        for chan in &slots {
+        for slot in &slots {
             unsafe {
-                free.send(chan.get() as *mut c_void);
+                free.send(slot.get() as *mut c_void);
             }
         }
 

--- a/zephyr/src/sys/queue.rs
+++ b/zephyr/src/sys/queue.rs
@@ -18,8 +18,8 @@ use zephyr_sys::{
 
 #[cfg(CONFIG_RUST_ALLOC)]
 use crate::error::Result;
-use crate::sys::K_FOREVER;
 use crate::object::{Fixed, StaticKernelObject, Wrapped};
+use crate::time::Timeout;
 
 /// A wrapper around a Zephyr `k_queue` object.
 pub struct Queue {
@@ -62,8 +62,14 @@ impl Queue {
     /// Get an element from a queue.
     ///
     /// This routine removes the first data item from the [`Queue`].
-    pub unsafe fn recv(&self) -> *mut c_void {
-        k_queue_get(self.item.get(), K_FOREVER)
+    /// The timeout value can be [`Forever`] to block until there is a message, [`NoWait`] to check
+    /// and immediately return if there is no message, or a [`Duration`] to indicate a specific
+    /// timeout.
+    pub unsafe fn recv<T>(&self, timeout: T) -> *mut c_void
+        where T: Into<Timeout>
+    {
+        let timeout: Timeout = timeout.into();
+        k_queue_get(self.item.get(), timeout.0)
     }
 }
 


### PR DESCRIPTION
Whereas the existing unbounded channels perform an allocation for each message sent, these bounded channels do a single allocation on initialization (of the channel, the zephyr queues used to implement it do an allocation). This allows send to block as well as recv.

This is the first part, coming soon will be send and receive with a timeout. This will allow using bounded channels from irq context (with no timeout).

Fixes #34 