### PR TITLE
Add bt_ APIs to the generated bindings

### DIFF
--- a/zephyr-sys/build.rs
+++ b/zephyr-sys/build.rs
@@ -72,6 +72,7 @@ fn main() -> Result<()> {
         .allowlist_function("gpio_.*")
         .allowlist_function("sys_.*")
         .allowlist_function("z_log.*")
+        .allowlist_function("bt_.*")
         .allowlist_item("E.*")
         .allowlist_item("K_.*")
         .allowlist_item("ZR_.*")

--- a/zephyr-sys/wrapper.h
+++ b/zephyr-sys/wrapper.h
@@ -34,6 +34,7 @@ extern int errno;
 #include <zephyr/kernel/thread_stack.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/bluetooth/bluetooth.h>
 
 /*
  * bindgen will output #defined constant that resolve to simple numbers.  There are some symbols


### PR DESCRIPTION
Add bt_ APIs to the generated bindings to enable bluetooth application development.