### PR TITLE
cmake: Set the release/debug based on Kconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,13 @@ function(rust_cargo_application)
 
   # TODO: Make sure RUSTFLAGS is not set.
 
-  # TODO: Let this be configurable, or based on Kconfig debug?
-  set(RUST_BUILD_TYPE debug)
+  if(CONFIG_DEBUG)
+    set(RUST_BUILD_TYPE "debug")
+    set(rust_build_type_arg "")
+  else()
+    set(RUST_BUILD_TYPE "release")
+    set(rust_build_type_arg "--release")
+  endif()
   set(BUILD_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${RUST_TARGET}/${RUST_BUILD_TYPE}")
 
   set(CARGO_TARGET_DIR "${CMAKE_CURRENT_BINARY_DIR}/rust/target")
@@ -152,8 +157,7 @@ ${config_paths}
       INCLUDE_DEFINES="${include_defines}"
       WRAPPER_FILE="${WRAPPER_FILE}"
       cargo build
-      # TODO: release flag if release build
-      # --release
+      ${rust_build_type_arg}
 
       # Override the features according to the shield given. For a general case,
       # this will need to come from a variable or argument.


### PR DESCRIPTION
Use the Zephyr KConfig `CONFIG_DEBUG` to determine if the Rust code should be built as release or debug.  This will better optimize the code.

Applications can still set options for `[profile.release]` to enable things such as run time assertions.  For example, debug symbols can still be enabled with `debug = "full"`, which attempts to insert debugging information, although the optimizer can still make the code challenging to debug.o

`debug-assertions = true`, and `overflow-checks = true` can still be enabled in the release builds, for some additional checks.