### PR TITLE
cmake: use project name instead of hardcoded name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,9 @@ function(rust_cargo_application)
   endif()
   set(BUILD_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${RUST_TARGET}/${RUST_BUILD_TYPE}")
 
+  set(RUST_LIBRARY_NAME "${CMAKE_PROJECT_NAME}")
   set(CARGO_TARGET_DIR "${CMAKE_CURRENT_BINARY_DIR}/rust/target")
-  set(RUST_LIBRARY "${CARGO_TARGET_DIR}/${RUST_TARGET}/${RUST_BUILD_TYPE}/librustapp.a")
+  set(RUST_LIBRARY "${CARGO_TARGET_DIR}/${RUST_TARGET}/${RUST_BUILD_TYPE}/lib${RUST_LIBRARY_NAME}.a")
   set(SAMPLE_CARGO_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/rust/sample-cargo-config.toml")
 
   # The generated C binding wrappers. These are bindgen-generated wrappers for the inline functions

--- a/samples/hello_world/CMakeLists.txt
+++ b/samples/hello_world/CMakeLists.txt
@@ -4,5 +4,5 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-project(hello_rust_world)
+project(hello_world)
 rust_cargo_application()

--- a/samples/hello_world/Cargo.toml
+++ b/samples/hello_world/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 # This must be rustapp for now.
-name = "rustapp"
+name = "hello_world"
 version = "3.7.0"
 edition = "2021"
 description = "A sample hello world application in Rust"

--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Hello world, but in Rust
-  name: hello rust world
+  name: hello world
 common:
   harness: console
   harness_config:

--- a/samples/philosophers/Cargo.toml
+++ b/samples/philosophers/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 # This must be rustapp for now.
-name = "rustapp"
+name = "philosophers"
 version = "3.7.0"
 edition = "2021"
 description = "A sample hello world application in Rust"

--- a/tests/time/CMakeLists.txt
+++ b/tests/time/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(time_rust)
+project(time)
 
 target_sources(app PRIVATE src/times.c)
 

--- a/tests/time/Cargo.toml
+++ b/tests/time/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 # This must be rustapp for now.
-name = "rustapp"
+name = "time"
 version = "3.7.0"
 edition = "2021"
 description = "Tests of time"

--- a/tests/timer/CMakeLists.txt
+++ b/tests/timer/CMakeLists.txt
@@ -3,6 +3,6 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(timer_rust)
+project(timer)
 
 rust_cargo_application()

--- a/tests/timer/Cargo.toml
+++ b/tests/timer/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 # This must be rustapp for now.
-name = "rustapp"
+name = "timer"
 version = "3.7.0"
 edition = "2021"
 description = "Tests of timeers"


### PR DESCRIPTION
This commit offers to give an arbitrary name to the Rust application project under CMake.

Indeed, before this commit, the CMake project for the Rust application had the name `librustapp`. Now, it can be set with any value.