### PR TITLE
Move to semantic versioning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ your application directory, with options set so that it can find the Zephyr supp
 that the output will be contained within the Zephyr build directory.
 
 The :file:`Cargo.toml` will need to have a ``[lib]`` section that sets ``crate-type =
-["staticlib"]``, and will need to include ``zephyr = "3.7.0"`` as a dependency.  You can use
+["staticlib"]``, and will need to include ``zephyr = "0.1.0"`` as a dependency.  You can use
 crates.io and the Crate ecosystem to include any other dependencies you need.  Just make sure that
 you use crates that support building with no-std.
 
@@ -115,7 +115,7 @@ To your ``Cargo.toml`` file, add the following:
 .. code-block:: toml
 
    [build-dependencies]
-   zephyr-build = "3.7.0"
+   zephyr-build = "0.1.0"
 
 Then, you will need a ``build.rs`` file to call the support function.  The following will work:
 

--- a/docgen/Cargo.toml
+++ b/docgen/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 # This must be rustapp for now.
 name = "rustapp"
-version = "3.7.0"
+version = "0.1.0"
 edition = "2021"
 description = "A small application to generate documentation"
 license = "Apache-2.0 or MIT"
@@ -13,4 +13,4 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = "3.7.0"
+zephyr = "0.1.0"

--- a/samples/hello_world/Cargo.toml
+++ b/samples/hello_world/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 # This must be rustapp for now.
 name = "rustapp"
-version = "3.7.0"
+version = "0.1.0"
 edition = "2021"
 description = "A sample hello world application in Rust"
 license = "Apache-2.0 or MIT"
@@ -13,5 +13,5 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = "3.7.0"
+zephyr = "0.1.0"
 log = "0.4.22"

--- a/samples/philosophers/Cargo.toml
+++ b/samples/philosophers/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 # This must be rustapp for now.
 name = "rustapp"
-version = "3.7.0"
+version = "0.1.0"
 edition = "2021"
 description = "A sample hello world application in Rust"
 license = "Apache-2.0 or MIT"
@@ -13,11 +13,11 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = "3.7.0"
+zephyr = "0.1.0"
 
 # Dependencies that are used by build.rs.
 [build-dependencies]
-zephyr-build = "3.7.0"
+zephyr-build = "0.1.0"
 
 [profile.release]
 debug-assertions = true

--- a/tests/time/Cargo.toml
+++ b/tests/time/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 # This must be rustapp for now.
 name = "rustapp"
-version = "3.7.0"
+version = "0.1.0"
 edition = "2021"
 description = "Tests of time"
 license = "Apache-2.0 or MIT"
@@ -13,4 +13,4 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = "3.7.0"
+zephyr = "0.1.0"

--- a/tests/timer/Cargo.toml
+++ b/tests/timer/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 # This must be rustapp for now.
 name = "rustapp"
-version = "3.7.0"
+version = "0.1.0"
 edition = "2021"
 description = "Tests of timeers"
 license = "Apache-2.0 or MIT"
@@ -15,4 +15,4 @@ crate-type = ["staticlib"]
 [dependencies]
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false }
-zephyr = "3.7.0"
+zephyr = "0.1.0"

--- a/zephyr-build/Cargo.toml
+++ b/zephyr-build/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "zephyr-build"
-version = "3.7.0"
+version = "0.1.0"
 edition = "2021"
 description = """
 Build-time support for Rust-based applications that run on Zephyr.

--- a/zephyr-sys/Cargo.toml
+++ b/zephyr-sys/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "zephyr-sys"
-version = "3.7.0"
+version = "0.1.0"
 edition = "2021"
 description = """
 Zephyr low-level API bindings.
@@ -15,4 +15,4 @@ Zephyr low-level API bindings.
 [build-dependencies]
 anyhow = "1.0"
 bindgen = { version = "0.69.4", features = ["experimental"] }
-# zephyr-build = { version = "3.7.0", path = "../zephyr-build" }
+# zephyr-build = { version = "0.1.0", path = "../zephyr-build" }

--- a/zephyr/Cargo.toml
+++ b/zephyr/Cargo.toml
@@ -3,14 +3,14 @@
 
 [package]
 name = "zephyr"
-version = "3.7.0"
+version = "0.1.0"
 edition = "2021"
 description = """
 Functionality for Rust-based applications that run on Zephyr.
 """
 
 [dependencies]
-zephyr-sys = { version = "3.7.0", path = "../zephyr-sys" }
+zephyr-sys = { version = "0.1.0", path = "../zephyr-sys" }
 
 # Although paste is brought in, it is a compile-time macro, and is not linked into the application.
 paste = "1.0"
@@ -48,4 +48,4 @@ features = ["alloc"]
 # Whether these need to be vendored is an open question.  They are not
 # used by the core Zephyr tree, but are needed by zephyr applications.
 [build-dependencies]
-zephyr-build = { version = "3.7.0", path = "../zephyr-build" }
+zephyr-build = { version = "0.1.0", path = "../zephyr-build" }


### PR DESCRIPTION
An earlier change updated all of the crate version numbers to match a Zephyr release.  This is problematic for several reasons:

- Zephyr releases don't correlate with semantic versions.  In general, it is probably best to assume every Zephyr release is a semantic change, and should have a major version bump.
- Cargo does make some assumptions about the meaning of semantic versions (for example, that it can use a version that would be considered semantically equivalent.
- The Rust support consists of multiple crates, and there is no particular reason to tie the version numbers of those together.

At this point, the Rust support for Zephyr is experimental, and definitely needs a 0.x.y version number.  Revert everything back to 0.1.0.  As this stabilizes more, we can start to come up with appropriate numbers.

Although we are quite a w ways from it making sense to include any of this in the crate ecosystem, it will still be helpful to have meaningful numbers if we ever do decide to do that.