### PR TITLE
samples: Properly filter samples by supported Rust targets

### DIFF
--- a/samples/blinky/sample.yaml
+++ b/samples/blinky/sample.yaml
@@ -1,6 +1,16 @@
 # See doc/develop/test/twister.rst for what is here.
 sample:
   name: Blinky Sample
+common:
+  filter: CONFIG_RUST_SUPPORTED
+  platform_allow:
+    - qemu_cortex_m0
+    - qemu_cortex_m3
+    - qemu_riscv32
+    - qemu_riscv32/qemu_virt_riscv32/smp
+    - qemu_riscv64
+    - qemu_riscv64/qemu_virt_riscv64/smp
+    - nrf52840dk/nrf52840
 tests:
   sample.basic.blinky:
     tags:

--- a/samples/philosophers/sample.yaml
+++ b/samples/philosophers/sample.yaml
@@ -11,6 +11,14 @@ common:
       - "c:\\[\\d{2,}, \\d{2,}, \\d{2,}, \\d{2,}, \\d{2,}, \\d{2,}\\]"
   tags: rust
   filter: CONFIG_RUST_SUPPORTED
+  platform_allow:
+    - qemu_cortex_m0
+    - qemu_cortex_m3
+    - qemu_riscv32
+    - qemu_riscv32/qemu_virt_riscv32/smp
+    - qemu_riscv64
+    - qemu_riscv64/qemu_virt_riscv64/smp
+    - nrf52840dk/nrf52840
 tests:
   sample.rust.philosopher.semaphore:
     tags: introduction


### PR DESCRIPTION
Without explicitly declaring the need for Rust support, twister tries to build these samples on targest that don't yet support Rust.  Include the filter, as well as an explicit platform allow of the supported targets.