### PR TITLE
samples/tests: Disable the smp targets

### DIFF
--- a/etc/platforms.txt
+++ b/etc/platforms.txt
@@ -1,7 +1,5 @@
 -p qemu_cortex_m0
 -p qemu_cortex_m3
 -p qemu_riscv32
--p qemu_riscv32/qemu_virt_riscv32/smp
 -p qemu_riscv64
--p qemu_riscv64/qemu_virt_riscv64/smp
 -p m2gl025_miv

--- a/samples/bench/sample.yaml
+++ b/samples/bench/sample.yaml
@@ -14,9 +14,7 @@ common:
     - qemu_cortex_m0
     - qemu_cortex_m3
     - qemu_riscv32
-    - qemu_riscv32/qemu_virt_riscv32/smp
     - qemu_riscv64
-    - qemu_riscv64/qemu_virt_riscv64/smp
     - nrf52840dk/nrf52840
 tests:
   sample.rust/bench.plain:

--- a/samples/blinky/sample.yaml
+++ b/samples/blinky/sample.yaml
@@ -7,9 +7,7 @@ common:
     - qemu_cortex_m0
     - qemu_cortex_m3
     - qemu_riscv32
-    - qemu_riscv32/qemu_virt_riscv32/smp
     - qemu_riscv64
-    - qemu_riscv64/qemu_virt_riscv64/smp
     - nrf52840dk/nrf52840
 tests:
   sample.basic.blinky:

--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -13,9 +13,7 @@ common:
     - qemu_cortex_m0
     - qemu_cortex_m3
     - qemu_riscv32
-    - qemu_riscv32/qemu_virt_riscv32/smp
     - qemu_riscv64
-    - qemu_riscv64/qemu_virt_riscv64/smp
     - nrf52840dk/nrf52840
 tests:
   sample.rust.helloworld:

--- a/samples/philosophers/sample.yaml
+++ b/samples/philosophers/sample.yaml
@@ -15,9 +15,7 @@ common:
     - qemu_cortex_m0
     - qemu_cortex_m3
     - qemu_riscv32
-    - qemu_riscv32/qemu_virt_riscv32/smp
     - qemu_riscv64
-    - qemu_riscv64/qemu_virt_riscv64/smp
     - nrf52840dk/nrf52840
 tests:
   sample.rust.philosopher.semaphore:

--- a/samples/work-philosophers/sample.yaml
+++ b/samples/work-philosophers/sample.yaml
@@ -13,9 +13,7 @@ common:
     - qemu_cortex_m0
     - qemu_cortex_m3
     - qemu_riscv32
-    - qemu_riscv32/qemu_virt_riscv32/smp
     - qemu_riscv64
-    - qemu_riscv64/qemu_virt_riscv64/smp
     - nrf52840dk/nrf52840
 tests:
   sample.rust.work-philosopher:

--- a/tests/time/testcase.yaml
+++ b/tests/time/testcase.yaml
@@ -4,9 +4,7 @@ common:
     - qemu_cortex_m0
     - qemu_cortex_m3
     - qemu_riscv32
-    - qemu_riscv32/qemu_virt_riscv32/smp
     - qemu_riscv64
-    - qemu_riscv64/qemu_virt_riscv64/smp
     - nrf52840dk/nrf52840
 tests:
   test.rust.time:

--- a/tests/timer/testcase.yaml
+++ b/tests/timer/testcase.yaml
@@ -4,9 +4,7 @@ common:
     - qemu_cortex_m0
     - qemu_cortex_m3
     - qemu_riscv32
-    - qemu_riscv32/qemu_virt_riscv32/smp
     - qemu_riscv64
-    - qemu_riscv64/qemu_virt_riscv64/smp
     - nrf52840dk/nrf52840
 tests:
   test.rust.timer:

--- a/zephyr/src/printk.rs
+++ b/zephyr/src/printk.rs
@@ -5,7 +5,10 @@
 //!
 //! This uses the `k_str_out` syscall, which is part of printk to output to the console.
 
-use core::fmt::{write, Arguments, Result, Write};
+use core::{
+    ffi::c_char,
+    fmt::{write, Arguments, Result, Write},
+};
 
 /// Print to Zephyr's console, without a newline.
 ///
@@ -92,7 +95,7 @@ impl Context {
     fn flush(&mut self) {
         if self.count > 0 {
             unsafe {
-                zephyr_sys::k_str_out(self.buf.as_mut_ptr() as *mut i8, self.count);
+                zephyr_sys::k_str_out(self.buf.as_mut_ptr() as *mut c_char, self.count);
             }
             self.count = 0;
         }


### PR DESCRIPTION
Currently, the smp targets seem to be deadlocking immediately on the first critical section.  For this release, disable these targets, and this can be investigated for the next release.