### PR TITLE
Deprecate old async

### DIFF
--- a/docgen/Cargo.toml
+++ b/docgen/Cargo.toml
@@ -13,4 +13,4 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = { version = "0.1.0", features = ["executor-zephyr", "async-drivers"] }
+zephyr = { version = "0.2.0", features = ["executor-zephyr", "async-drivers"] }

--- a/samples/bench/Cargo.toml
+++ b/samples/bench/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = "0.1.0"
+zephyr = "0.2.0"
 critical-section = "1.1.2"
 
 # Dependencies that are used by build.rs.

--- a/samples/bench/src/lib.rs
+++ b/samples/bench/src/lib.rs
@@ -6,6 +6,8 @@
 // uses a large number of Kconfigs and there is no easy way to know which ones might conceivably be
 // valid.  This prevents a warning about each cfg that is used.
 #![allow(unexpected_cfgs)]
+// While in the process of deprecating the "kio" async code, allow the deprecation warnings.
+#![allow(deprecated)]
 
 extern crate alloc;
 

--- a/samples/blinky/Cargo.toml
+++ b/samples/blinky/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0 OR MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = "0.1.0"
+zephyr = "0.2.0"
 log = "0.4.22"
 
 [build-dependencies]

--- a/samples/embassy/Cargo.toml
+++ b/samples/embassy/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = { version = "0.1.0", features = ["time-driver"] }
+zephyr = { version = "0.2.0", features = ["time-driver"] }
 log = "0.4.22"
 static_cell = "2.1"
 heapless = "0.8"

--- a/samples/hello_world/Cargo.toml
+++ b/samples/hello_world/Cargo.toml
@@ -13,5 +13,5 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = "0.1.0"
+zephyr = "0.2.0"
 log = "0.4.22"

--- a/samples/philosophers/Cargo.toml
+++ b/samples/philosophers/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = "0.1.0"
+zephyr = "0.2.0"
 
 # Dependencies that are used by build.rs.
 [build-dependencies]

--- a/samples/work-philosophers/Cargo.toml
+++ b/samples/work-philosophers/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = "0.1.0"
+zephyr = "0.2.0"
 
 # Dependencies that are used by build.rs.
 [build-dependencies]

--- a/samples/work-philosophers/src/lib.rs
+++ b/samples/work-philosophers/src/lib.rs
@@ -6,6 +6,8 @@
 // uses a large number of Kconfigs and there is no easy way to know which ones might conceivably be
 // valid.  This prevents a warning about each cfg that is used.
 #![allow(unexpected_cfgs)]
+// During the transition of deprecating 'kio' async, allow the deprecation warnings.
+#![allow(deprecated)]
 
 extern crate alloc;
 

--- a/tests/time/Cargo.toml
+++ b/tests/time/Cargo.toml
@@ -13,4 +13,4 @@ license = "Apache-2.0 or MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
-zephyr = "0.1.0"
+zephyr = "0.2.0"

--- a/tests/timer/Cargo.toml
+++ b/tests/timer/Cargo.toml
@@ -15,4 +15,4 @@ crate-type = ["staticlib"]
 [dependencies]
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false }
-zephyr = "0.1.0"
+zephyr = "0.2.0"

--- a/zephyr/Cargo.toml
+++ b/zephyr/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "zephyr"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = """
 Functionality for Rust-based applications that run on Zephyr.

--- a/zephyr/src/kio.rs
+++ b/zephyr/src/kio.rs
@@ -20,12 +20,14 @@ use crate::work::{futures::JoinHandle, futures::WorkBuilder, WorkQueue};
 
 pub mod sync;
 
+#[allow(deprecated)]
 pub use crate::work::futures::sleep;
 
 /// Run an async future on the given worker thread.
 ///
 /// Arrange to have the given future run on the given worker thread.  The resulting `JoinHandle` has
 /// `join` and `join_async` methods that can be used to wait for the given thread.
+#[deprecated(since = "0.1.0", note = "Prefer the executor-zephyr")]
 pub fn spawn<F>(future: F, worker: &WorkQueue, name: &'static CStr) -> JoinHandle<F>
 where
     F: Future + Send + 'static,
@@ -54,6 +56,7 @@ where
 ///
 /// # Panics
 /// If this is called other than from a worker task running on a work thread, it will panic.
+#[deprecated(since = "0.1.0", note = "Prefer the executor-zephyr")]
 pub fn spawn_local<F>(future: F, name: &'static CStr) -> JoinHandle<F>
 where
     F: Future + 'static,
@@ -64,6 +67,7 @@ where
 
 /// Yield the current thread, returning it to the work queue to be run after other work on that
 /// queue.  (This has to be called `yield_now` in Rust, because `yield` is a keyword.)
+#[deprecated(since = "0.1.0", note = "Prefer the executor-zephyr")]
 pub fn yield_now() -> impl Future<Output = ()> {
     YieldNow { waited: false }
 }

--- a/zephyr/src/kio/sync.rs
+++ b/zephyr/src/kio/sync.rs
@@ -31,6 +31,7 @@ use crate::{
 /// A mutual exclusion primitive useful for protecting shared data.  Async version.
 ///
 /// This mutex will block a task waiting for the lock to become available.
+#[deprecated(since = "0.1.0", note = "Prefer the executor-zephyr")]
 pub struct Mutex<T: ?Sized> {
     /// The semaphore indicating ownership of the data.  When it is "0" the task that did the 'take'
     /// on it owns the data, and will use `give` when it is unlocked.  This mechanism works for
@@ -40,9 +41,12 @@ pub struct Mutex<T: ?Sized> {
 }
 
 // SAFETY: The semaphore, with the semantics provided here, provide Send and Sync.
+#[allow(deprecated)]
 unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
+#[allow(deprecated)]
 unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
 
+#[allow(deprecated)]
 impl<T> fmt::Debug for Mutex<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Mutex {:?}", self.inner)
@@ -50,6 +54,7 @@ impl<T> fmt::Debug for Mutex<T> {
 }
 
 /// An RAII implementation of a held lock.
+#[allow(deprecated)]
 pub struct MutexGuard<'a, T: ?Sized + 'a> {
     lock: &'a Mutex<T>,
     // Mark !Send explicitly until support is added to Rust for this.
@@ -58,6 +63,7 @@ pub struct MutexGuard<'a, T: ?Sized + 'a> {
 
 unsafe impl<T: ?Sized + Sync> Sync for MutexGuard<'_, T> {}
 
+#[allow(deprecated)]
 impl<T> Mutex<T> {
     /// Construct a new Mutex.
     pub fn new(t: T) -> Mutex<T> {
@@ -68,6 +74,7 @@ impl<T> Mutex<T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T: ?Sized> Mutex<T> {
     /// Acquire the mutex, blocking the current thread until it is able to do so.
     ///
@@ -94,6 +101,7 @@ impl<T: ?Sized> Mutex<T> {
     }
 }
 
+#[allow(deprecated)]
 impl<'mutex, T: ?Sized> MutexGuard<'mutex, T> {
     unsafe fn new(lock: &'mutex Mutex<T>) -> MutexGuard<'mutex, T> {
         MutexGuard {
@@ -103,6 +111,7 @@ impl<'mutex, T: ?Sized> MutexGuard<'mutex, T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T: ?Sized> Deref for MutexGuard<'_, T> {
     type Target = T;
 
@@ -111,12 +120,14 @@ impl<T: ?Sized> Deref for MutexGuard<'_, T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.lock.data.get() }
     }
 }
 
+#[allow(deprecated)]
 impl<T: ?Sized> Drop for MutexGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {

--- a/zephyr/src/sync/channel.rs
+++ b/zephyr/src/sync/channel.rs
@@ -215,6 +215,7 @@ impl<T: Unpin> Sender<T> {
     /// This has the same behavior as [`send_timeout`], but as an Async function.
     ///
     /// [`send_timeout`]: Sender::send_timeout
+    #[deprecated(since = "0.1.0", note = "Prefer the executor-zephyr")]
     pub fn send_timeout_async<'a>(
         &'a self,
         msg: T,
@@ -229,6 +230,8 @@ impl<T: Unpin> Sender<T> {
     }
 
     /// Sends a message over the given channel, waiting if necessary. Async version.
+    #[deprecated(since = "0.1.0", note = "Prefer the executor-zephyr")]
+    #[allow(deprecated)]
     pub async fn send_async(&self, msg: T) -> Result<(), SendError<T>> {
         self.send_timeout_async(msg, Forever).await
     }
@@ -424,6 +427,7 @@ impl<T> Receiver<T> {
 }
 
 // Note that receive doesn't need the Unpin constraint, as we aren't storing any message.
+#[deprecated(since = "0.1.0", note = "Prefer the executor-zephyr")]
 impl<T> Receiver<T> {
     /// Waits for a message to be received from the channel, but only for a limited time.
     /// Async version.
@@ -526,6 +530,7 @@ impl<'a, T> Future for RecvFuture<'a, T> {
         }
 
         // Otherwise, schedule to wakeup on receipt or timeout.
+        #[allow(deprecated)]
         cx.add_queue(self.receiver.as_queue(), self.timeout);
         self.waited = true;
 
@@ -662,6 +667,7 @@ where
     // Start with a deadline 'period' out in the future.
     let mut next = crate::time::now() + period;
     loop {
+        #[allow(deprecated)]
         if let Ok(ev) = events.recv_timeout_async(next).await {
             handle(Some(ev)).await;
             continue;

--- a/zephyr/src/sys/sync/semaphore.rs
+++ b/zephyr/src/sys/sync/semaphore.rs
@@ -82,6 +82,7 @@ impl Semaphore {
     ///
     /// Returns a future that either waits for the semaphore, or returns status.
     #[cfg(CONFIG_RUST_ALLOC)]
+    #[deprecated(since = "0.1.0", note = "Prefer the executor-zephyr")]
     pub fn take_async<'a>(
         &'a self,
         timeout: impl Into<Timeout>,

--- a/zephyr/src/work/futures.rs
+++ b/zephyr/src/work/futures.rs
@@ -104,6 +104,7 @@ impl<T> Answer<T> {
 
     /// Asynchronously wait for an answer.
     pub async fn take_async(&self) -> T {
+        #[allow(deprecated)]
         self.wake
             .take_async(Forever)
             .await
@@ -587,6 +588,7 @@ unsafe fn void_drop(_: *const ()) {}
 type EventArray = ArrayVec<UnsafeCell<k_poll_event>, 1>;
 
 /// Async sleep.
+#[deprecated(since = "0.1.0", note = "Prefer the executor-zephyr")]
 pub fn sleep(duration: Duration) -> Sleep {
     Sleep {
         ticks_left: duration.ticks(),


### PR DESCRIPTION
Begin the process of deprecating the old "async" implementation. This implementation has numerous problems:
- It is fundamentally incompatible with how async executors are expected to work. Trying to combine with other libraries that expect async will either result in a `panic`, or even undefined behavior.
- They are only usable with a limited set of scheduling primitives, notably Zephyr's `k_sem`, and `k_queue`. This is largely a limitation of what is supported by triggered in Zephyr.
- They're not useful for much else. In order to work with something like a driver callback, that interface would have to use a Semaphore or Channel, since the Waker from the async call itself cannot be used.
- They aren't very efficient. Using triggered work ends up using the combined overhead of threads, and work queues. Using the utilities provided by Embassy allows same-thread scheduling to be very low overhead, while bringing in the thread scheduling overhead only when wakes will cross thread boundaries.

The proposed alternative is to use the `Executor` provided by the feature `executor-zephyr`. This is a very lightweight executor, making use of some utilities provided by Embassy to allow lightweight scheduling on a single thread, and reasonably efficient scheduling across Zephyr threads. Async device operations can use the `Waker` mechanism as designed to be able to provide nice async Rust interfaces to drivers.