### PR TITLE
task + async misc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,8 @@ jobs:
         working-directory: zephyr-lang-rust
         run: |
           # Note that the above build doesn't set Zephyrbase, so we'll need to do that here.
-          west build -t rustdoc -b qemu_cortex_m3 docgen
+          west build -b qemu_cortex_m3 docgen
+          west build -t rustdoc
           mkdir rustdocs
           mv build/rust/target/thumbv7m-none-eabi/doc rustdocs/nostd
 

--- a/samples/bench/src/lib.rs
+++ b/samples/bench/src/lib.rs
@@ -619,15 +619,16 @@ impl Simple {
         );
 
         // Before we go away, make sure that there aren't any leaked workers.
-        /*
         let mut locked = main.action().locked.lock().unwrap();
         while let Some(other) = locked.works.pop_front() {
-            // Portable atomic's Arc seems to be a problem here.
-            let other = unsafe { Pin::into_inner_unchecked(other) };
+            let other = Pin::into_inner(other);
             assert_eq!(Arc::strong_count(&other), 1);
-            // printkln!("Child: {} refs", Arc::strong_count(&other));
         }
-        */
+        drop(locked);
+
+        // And nothing has leaked main, either.
+        let main = Pin::into_inner(main);
+        assert_eq!(Arc::strong_count(&main), 1);
     }
 }
 

--- a/samples/bench/src/lib.rs
+++ b/samples/bench/src/lib.rs
@@ -583,7 +583,7 @@ impl Simple {
 
     fn run(&self, workers: usize, iterations: usize) {
         // printkln!("Running Simple");
-        let main = Work::new(SimpleMain::new(workers * iterations, self.workq));
+        let main: Pin<Arc<Work<_>>> = Work::new(SimpleMain::new(workers * iterations, self.workq));
 
         let children: VecDeque<_> = (0..workers)
             .map(|n| Work::new(SimpleWorker::new(main.clone(), self.workq, n)))

--- a/samples/embassy/Cargo.toml
+++ b/samples/embassy/Cargo.toml
@@ -28,17 +28,16 @@ features = [
 
 [dependencies.embassy-futures]
 version = "0.1.1"
-# path = "../../embassy/embassy-futures"
 
 [dependencies.embassy-sync]
 version = "0.6.2"
-# path = "../../embassy/embassy-sync"
 
 [dependencies.embassy-time]
 version = "0.4.0"
-# path = "../../embassy/embassy-time"
-# This is board specific.
-features = ["tick-hz-10_000"]
+# For real builds, you should figure out your target's tick rate and set the appropriate feature,
+# like in these examples.  Without this, embassy-time will assume a 1Mhz tick rate, and every time
+# operation will involve a conversion.
+#features = ["tick-hz-10_000"]
 
 [dependencies.critical-section]
 version = "1.2"

--- a/tests/drivers/gpio-async/README.md
+++ b/tests/drivers/gpio-async/README.md
@@ -1,0 +1,6 @@
+# Async gpio
+
+This demo makes use of the GPIO `wait_for_high()` and `wait_for_low()` async operations.
+
+Unfortunately, not all GPIO controllers support level triggered interrupts.  Notably, most of the
+stm32 line does not support level triggered interrupts.

--- a/zephyr-build/src/devicetree/augment.rs
+++ b/zephyr-build/src/devicetree/augment.rs
@@ -28,6 +28,12 @@ pub trait Augment {
     /// The default implementation checks if this node matches and calls a generator if it does, or
     /// does nothing if not.
     fn augment(&self, node: &Node, tree: &DeviceTree) -> TokenStream {
+        // If there is a status field present, and it is not set to "okay", don't augment this node.
+        if let Some(status) = node.get_single_string("status") {
+            if status != "okay" {
+                return TokenStream::new();
+            }
+        }
         if self.is_compatible(node) {
             self.generate(node, tree)
         } else {

--- a/zephyr-macros/Cargo.toml
+++ b/zephyr-macros/Cargo.toml
@@ -9,7 +9,7 @@ descriptions = "Macros for managing tasks and work queues in Zephyr"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.85", features = ["full", "visit"] }
+syn = { version = "2.0.79", features = ["full", "visit"] }
 quote = "1.0.37"
 proc-macro2 = "1.0.86"
 darling = "0.20.1"

--- a/zephyr/src/embassy.rs
+++ b/zephyr/src/embassy.rs
@@ -71,7 +71,7 @@
 //!
 //! ## Caveats
 //!
-//! [`Semaphore::take_async`]: crate::sys::sync::Semaphore::take_async
+//! The executor currently doesn't support async waits on Zephyr primitives, such as Semaphore.
 
 #[cfg(feature = "time-driver")]
 mod time_driver;

--- a/zephyr/src/lib.rs
+++ b/zephyr/src/lib.rs
@@ -39,7 +39,7 @@
 //!     level operation that is still quite useful in regular code.
 //! - [`timer`]: Rust interfaces to Zephyr timers.  These timers can be used either by registering a
 //!   callback, or polled or waited for for an elapsed time.
-//! - [`work`]: Zephyr work queues for Rust.  The [`work::WorkQueueBuilder`] and resulting
+//! - [`work`]: Zephyr work queues for Rust.  The [`define_work_queue`] macro and resulting
 //!   [`work::WorkQueue`] allow creation of Zephyr work queues to be used from Rust.  The
 //!   [`work::Work`] item had an action that will be invoked by the work queue, and can be manually
 //!   submitted when needed.

--- a/zephyr/src/sync.rs
+++ b/zephyr/src/sync.rs
@@ -57,6 +57,21 @@ mod pinweak {
                 .upgrade()
                 .map(|arc| unsafe { Pin::new_unchecked(arc) })
         }
+
+        /// Equivalent to [`Weak::strong_count`]
+        pub fn strong_count(&self) -> usize {
+            self.0.strong_count()
+        }
+
+        /// Equivalent to [`Weak::weak_count`]
+        pub fn weak_count(&self) -> usize {
+            self.0.weak_count()
+        }
+
+        /// Equivalent to [`Weak::ptr_eq`]
+        pub fn ptr_eq(&self, other: &Self) -> bool {
+            self.0.ptr_eq(&other.0)
+        }
     }
 }
 


### PR DESCRIPTION
Create a new proc-macro-based way of declaring threads in Zephyr. Instead of the weird `kobj_define` macro, provide a `zephyr::thread` macro that can decorate an ordinary Rust function to become a builder for a `ReadyThread` that can just be started. Threads can also now be reused after they exit.

This allows something like:
```rust
#[zephyr::thread(stack_size = 2048)]
fn mythread(name: &'static str, index: usize) {
    // Body
}
```

and somewhere in the code, you just call it, which returns a handle that can be used to start the thread.
```rust
let joiner = mythread("thename", 42).start();
...
joiner.join();  // Wait for thread to exit, if desired.
```

There is still some things to clean up, hence the draft, but I wanted to get some exposure.