### PR TITLE
Added "\r" to WHITESPACE char for windows build.

### DIFF
--- a/zephyr-build/src/devicetree/dts.pest
+++ b/zephyr-build/src/devicetree/dts.pest
@@ -74,4 +74,4 @@ nodename = @{
     (ASCII_ALPHANUMERIC | "_" | "," | "." | "?" | "-" | "@" | "#")+
 }
 
-WHITESPACE = _{ " " | "\n" | "\t" }
+WHITESPACE = _{ " " | "\r" | "\n" | "\t" }


### PR DESCRIPTION
see: https://github.com/zephyrproject-rtos/zephyr-lang-rust/issues/68