### PR TITLE
Fix two issues with samples/tests affecting CI

### DIFF
--- a/samples/blinky/sample.yaml
+++ b/samples/blinky/sample.yaml
@@ -17,5 +17,3 @@ tests:
     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")
     depends_on: gpio
     harness: led
-    integration_platforms:
-      - frdm_k64f

--- a/samples/blinky/sample.yaml
+++ b/samples/blinky/sample.yaml
@@ -10,7 +10,7 @@ common:
     - qemu_riscv64
     - nrf52840dk/nrf52840
 tests:
-  sample.basic.blinky:
+  sample.rust.basic.blinky:
     tags:
       - LED
       - gpio

--- a/tests/drivers/gpio-async/testcase.yaml
+++ b/tests/drivers/gpio-async/testcase.yaml
@@ -3,7 +3,7 @@ common:
   platform_allow:
     - rpi_pico
 tests:
-  test.gpio-async:
+  test.rust.drivers.gpio-async:
     harness: console
     harness_config:
       type: one_line


### PR DESCRIPTION
- Ensure each test/sample has a name distinct from all samples/tests in Zephyr.
- Remove an invalid integration platform from a test. Until this target is supported, don't try the integration test.