### PR TITLE
Add rust-toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,12 @@
+[toolchain]
+channel = "1.85"
+components = [ "rust-src", "rustfmt", "llvm-tools" ]
+targets = [
+    "thumbv7em-none-eabi",
+    "thumbv7m-none-eabi",
+    "thumbv6m-none-eabi",
+    "thumbv7em-none-eabihf",
+    "thumbv8m.main-none-eabihf",
+    "riscv32i-unknown-none-elf",
+    "riscv64imac-unknown-none-elf",
+]


### PR DESCRIPTION
This specifies the exact tools that need to be present in order to build these projects.  This should affect all of the samples.

Currently, we require Rust 1.85 for a few reasons.  There have been some subtle changes to warnings that cause build failures with older version. Specifically, the 2024 edition requires certain attributes to explicitly be marked as unsafe, but the construct to mark them as unsafe is only present in the 2024 compiler.  There are also some subtle changes to warnings that affect our builds.