### PR TITLE
cmake: add USES_TERMINAL to show cargo output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ ${config_paths}
   add_custom_command(
     OUTPUT ${DUMMY_FILE}
     BYPRODUCTS ${RUST_LIBRARY} ${WRAPPER_FILE}
+    USES_TERMINAL
     COMMAND
       ${CMAKE_COMMAND} -E
       env BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
@@ -199,6 +200,7 @@ ${config_paths}
   # it is important to keep this in sync with the above.
   add_custom_command(
     OUTPUT generate_rust_docs
+    USES_TERMINAL
     COMMAND
       ${CMAKE_COMMAND} -E
       env BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
Otherwise the CMake output is just stuck at the rust build step for
however long it takes to build.

Signed-Off-By: Johannes Schilling <github@deaktualisierung.org>