### PR TITLE
zephyr: Replace critical-section implementation

### DIFF
--- a/zephyr-sys/build.rs
+++ b/zephyr-sys/build.rs
@@ -77,6 +77,7 @@ fn main() -> Result<()> {
         .allowlist_function("k_.*")
         .allowlist_function("gpio_.*")
         .allowlist_function("flash_.*")
+        .allowlist_function("zr_.*")
         .allowlist_item("GPIO_.*")
         .allowlist_item("FLASH_.*")
         .allowlist_item("Z_.*")

--- a/zephyr-sys/wrapper.h
+++ b/zephyr-sys/wrapper.h
@@ -42,6 +42,7 @@ extern int errno;
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/irq.h>
 
 /*
  * bindgen will only output #defined constants that resolve to simple numbers.  These are some
@@ -61,3 +62,15 @@ const uint32_t ZR_POLL_TYPE_DATA_AVAILABLE = K_POLL_TYPE_DATA_AVAILABLE;
 const uint32_t ZR_GPIO_INT_MODE_DISABLE_ONLY = GPIO_INT_MODE_DISABLE_ONLY;
 const uint32_t ZR_GPIO_INT_MODE_ENABLE_ONLY = GPIO_INT_MODE_ENABLE_ONLY;
 #endif
+
+/*
+ * Zephyr's irq_lock() and irq_unlock() are macros not inline functions, so we need some inlines to
+ * access them.
+ */
+static inline int zr_irq_lock(void) {
+	return irq_lock();
+}
+
+static inline void zr_irq_unlock(int key) {
+	irq_unlock(key);
+}


### PR DESCRIPTION
There is a fairly fundamental incompatibility between Zephyr spin locks and the Critical Section specification.  Zephyr spin locks do not allow nesting from within a single spin lock.  The critical section API only has an `acquire` and `release` entry, and provides no way (such as a stack frame) to have a unique context for different invocation places.

Unfortunately, this means we cannot use spin locks for critical sections.

Instead, this change implements critical sections using irq locking. The implementation of these macros on Zephyr does try to make them SMP safe, with a simple atomic lock, but there is still something preventing the riscv SMP from working.

Also, these entries cannot be called from user mode.  There are various other reasons we don't support usermode, so at this time, just have a compile time assertion that usermode is not enabled in the build.  If it is needed, we will have to come up with another way to implement this.