### PR TITLE
zephyr: devicetree: Allow non-snake-case names in DT nodes

### DIFF
--- a/zephyr/src/lib.rs
+++ b/zephyr/src/lib.rs
@@ -129,6 +129,9 @@ pub mod devicetree {
 
     // Don't enforce doc comments on the generated device tree.
     #![allow(missing_docs)]
+    // Allow nodes to have non-snake-case names.  This comes from addresses in the node names, which
+    // usually use uppercase.
+    #![allow(non_snake_case)]
 
     include!(concat!(env!("OUT_DIR"), "/devicetree.rs"));
 }


### PR DESCRIPTION
DT nodes that have addresses with hex letters in them will generate names with capital letters inside the name, which will trigger the `non_snake_case` lint in the compiler.  Pre-emptively allow these names in the devicetree, as this will show up as new targets are added.