### PR TITLE
feat(cargo): Set rustc-check-cfg for all config options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,20 @@ DT_AUGMENTS = \"${DT_AUGMENTS}\"
 ${config_paths}
 ")
 
+  set(RUST_KCONFIG_BOOL_OPTIONS_FILE "${CMAKE_CURRENT_BINARY_DIR}/rust-kconfig-bool-options.json")
+
+  add_custom_command(
+    OUTPUT ${RUST_KCONFIG_BOOL_OPTIONS_FILE}
+    COMMAND
+      ${CMAKE_COMMAND} -E
+      env ${COMMON_KCONFIG_ENV_SETTINGS}
+      ${RUST_MODULE_DIR}/scripts/kconfig-bool-options.py ${KCONFIG_ROOT} ${DOTCONFIG}
+      ${RUST_KCONFIG_BOOL_OPTIONS_FILE}
+    DEPENDS ${DOTCONFIG}
+    COMMENT "Finding valid kconfig boolean options"
+    WORKING_DIRECTORY ${APPLICATION_SOURCE_DIR}
+  )
+
   # The block of environment variables below could theoretically be captured in a variable, but this
   # seems "challenging" in CMake (to be polite), as many of these contain spaces, and the quoting
   # rules in CMake are inconsistent, at best.
@@ -161,6 +175,7 @@ ${config_paths}
   add_custom_command(
     OUTPUT ${DUMMY_FILE}
     BYPRODUCTS ${RUST_LIBRARY} ${WRAPPER_FILE}
+    DEPENDS ${RUST_KCONFIG_BOOL_OPTIONS_FILE}
     USES_TERMINAL
     COMMAND
       ${CMAKE_COMMAND} -E

--- a/samples/async-philosophers/src/lib.rs
+++ b/samples/async-philosophers/src/lib.rs
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![no_std]
-// Cargo tries to detect configs that have typos in them.  Unfortunately, the Zephyr Kconfig system
-// uses a large number of Kconfigs and there is no easy way to know which ones might conceivably be
-// valid.  This prevents a warning about each cfg that is used.
-#![allow(unexpected_cfgs)]
 
 extern crate alloc;
 

--- a/samples/bench/src/lib.rs
+++ b/samples/bench/src/lib.rs
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![no_std]
-// Cargo tries to detect configs that have typos in them.  Unfortunately, the Zephyr Kconfig system
-// uses a large number of Kconfigs and there is no easy way to know which ones might conceivably be
-// valid.  This prevents a warning about each cfg that is used.
-#![allow(unexpected_cfgs)]
 
 extern crate alloc;
 

--- a/samples/philosophers/src/lib.rs
+++ b/samples/philosophers/src/lib.rs
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![no_std]
-// Cargo tries to detect configs that have typos in them.  Unfortunately, the Zephyr Kconfig system
-// uses a large number of Kconfigs and there is no easy way to know which ones might conceivably be
-// valid.  This prevents a warning about each cfg that is used.
-#![allow(unexpected_cfgs)]
 
 extern crate alloc;
 

--- a/scripts/kconfig-bool-options.py
+++ b/scripts/kconfig-bool-options.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import argparse
+import json
+
+from itertools import chain
+
+sys.path.insert(0, str(os.path.join(os.environ["ZEPHYR_BASE"], "scripts", "kconfig")))
+from kconfiglib import Kconfig, _T_BOOL, _T_CHOICE
+
+
+def main():
+    args = parse_args()
+
+    kconf = Kconfig(args.kconfig_file)
+    kconf.load_config(args.dotconfig)
+
+    options = {}
+
+    for sym in chain(kconf.unique_defined_syms, kconf.unique_choices):
+        if not sym.name:
+            continue
+
+        if "-" in sym.name:
+            # Rust does not allow hyphens in cfg options.
+            continue
+
+        if sym.type in [_T_BOOL, _T_CHOICE]:
+            options[f"CONFIG_{sym.name}"] = sym.str_value
+
+    with open(args.outfile, "w") as f:
+        json.dump(options, f, indent=2, sort_keys=True)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+
+    parser.add_argument("kconfig_file", help="Top-level Kconfig file")
+    parser.add_argument("dotconfig", help="Path to dotconfig file")
+    parser.add_argument("outfile", help="Path to output file")
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This squashes lint warnings for config options which are not currently enabled.

See https://doc.rust-lang.org/cargo/reference/build-scripts.html\#rustc-check-cfg