### PR TITLE
zephyr: Specify minimum rust version

### DIFF
--- a/zephyr/Cargo.toml
+++ b/zephyr/Cargo.toml
@@ -9,6 +9,9 @@ description = """
 Functionality for Rust-based applications that run on Zephyr.
 """
 
+# 1.85 is needed to support working with or without edition 2024.
+rust-version = "1.85"
+
 [dependencies]
 zephyr-sys = { version = "0.1.0", path = "../zephyr-sys" }
 zephyr-macros = { version = "0.1.0", path = "../zephyr-macros" }


### PR DESCRIPTION
To allow the 2024 edition of Rust to be used, one of our macros needs a new syntax, introduced in Rust 1.85 to declare that it is known that the macro expansion is unsafe.

This could work without the minimum rust version, as long as the macro isn't used, but is needed for tests, and Rust stable has already moved to 1.86, so it isn't an onerous requirement.