### PR TITLE
dts.pest: Add support for comments in devicetree source files

### DIFF
--- a/zephyr-build/src/devicetree/dts.pest
+++ b/zephyr-build/src/devicetree/dts.pest
@@ -75,3 +75,4 @@ nodename = @{
 }
 
 WHITESPACE = _{ " " | "\n" | "\t" }
+COMMENT = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }


### PR DESCRIPTION
Add support for comments in devicetree source files by extending the existing parser grammar. This is currently required to allow CI to pass on zephyrproject-rtos/zephyr#89410. 

I have zero experience on Rust, but the `COMMENT =` syntax is taken verbatim from an example on the [Pest website](https://pest.rs/book/grammars/syntax.html#implicit-whitespace), and I also tried the change on the live editor there, so... I'm pretty hopeful :slightly_smiling_face:

EDIT: CI passed on the manifest update PR (see message below)