### PR TITLE
dts.pest: Add support for comments in devicetree source files [main branch]

### DIFF
--- a/zephyr-build/src/devicetree/dts.pest
+++ b/zephyr-build/src/devicetree/dts.pest
@@ -75,3 +75,4 @@ nodename = @{
 }
 
 WHITESPACE = _{ " " | "\r" | "\n" | "\t" }
+COMMENT = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }


### PR DESCRIPTION
Apply to `main` the same change that was just merged to `v4.1-branch` with #96.