### PR TITLE
Port to STM32

### DIFF
--- a/dt-rust.yaml
+++ b/dt-rust.yaml
@@ -44,6 +44,7 @@
       - "nordic,nrf52-flash-controller"
       - "nordic,nrf51-flash-controller"
       - "raspberrypi,pico-flash-controller"
+      - "st,stm32-flash-controller"
       level: 0
   actions:
   - type: instance


### PR DESCRIPTION
Augment flash controllers with their instance on STM32.

This works on current zephyr main - e92677bd3cceb27079d7cb1e3f783d809edea362. It runs the hello world sample on nucleo_wl55jc, but fails with:

```
panic: panicked at library/alloc/src/alloc.rs:437:13:
memory allocation of 8 bytes failed
*** Booting Zephyr OS build v4.1.0-4886-ge92677bd3cce ***
[00:00:00.000,000] <err> os: CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE is 0
[00:00:00.008,000] <err> os: r0/a1:  0x00000004  r1/a2:  0x0000000a  r2/a3:  0x00000000
[00:00:00.008,000] <err> os: r3/a4:  0x00000004 r12/ip:  0x200022f4 r14/lr:  0x08007f5b
[00:00:00.008,000] <err> os:  xpsr:  0x21000000
[00:00:00.008,000] <err> os: Faulting instruction address (r15/pc): 0x08004e48
[00:00:00.008,000] <err> os: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
[00:00:00.008,000] <err> os: Current thread: 0x200005e8 (unknown)
[00:00:00.025,000] <err> os: Halting system
```

This is easily solved with `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=4096` in prj.conf. I can add this to this pull request or separately if you prefer, but I don't know what is suitable for all samples and tests.

```
[00:00:00.000,000] <inf> rust: rustapp: Hello world from Rust on nucleo_wl55jc
```

I also tried to add this on main, but DTS parsing fails due to the parser not accepting the origin comments produced by zephyr, it seems. I assume you would like this change introduced there, and then backported.