### PR TITLE
zephyr: work: Allow struct to have a additional fields

### DIFF
--- a/zephyr-sys/build.rs
+++ b/zephyr-sys/build.rs
@@ -74,6 +74,7 @@ fn main() -> Result<()> {
         .clang_arg("-DRUST_BINDGEN")
         .clang_arg(format!("-I{}/lib/libc/minimal/include", zephyr_base))
         .derive_copy(false)
+        .derive_default(true)
         .allowlist_function("k_.*")
         .allowlist_function("gpio_.*")
         .allowlist_function("flash_.*")

--- a/zephyr/src/work.rs
+++ b/zephyr/src/work.rs
@@ -105,7 +105,6 @@ use core::{
     ffi::{c_int, c_uint, CStr},
     mem,
     pin::Pin,
-    ptr,
 };
 
 use zephyr_sys::{
@@ -138,11 +137,7 @@ impl WorkQueueBuilder {
     /// Construct a new WorkQueueBuilder with default values.
     pub fn new() -> Self {
         Self {
-            config: k_work_queue_config {
-                name: ptr::null(),
-                no_yield: false,
-                essential: false,
-            },
+            config: Default::default(),
             priority: 0,
         }
     }


### PR DESCRIPTION
Structs in the C world assume zero initialization, and therefore adding fields is not considered an API change.  Support this for an upcoming API change in the work queue config, by deriving default for these structs, and using this zero-init as a default.  This should support fields being added to this struct. The rust code will zero init the unknown fields, which will have the same behavior as the C code.

This should allow zephyr#88345 to be merged, as well as allow the Rust code to work both before and after this change.