### PR TITLE
dts: only generate getters for okay nodes

### DIFF
--- a/zephyr-build/src/devicetree/augment.rs
+++ b/zephyr-build/src/devicetree/augment.rs
@@ -191,23 +191,30 @@ impl RawInfo {
             Self::Myself => {
                 let ord = node.ord;
                 let rawdev = format_ident!("__device_dts_ord_{}", ord);
-                quote! {
-                    /// Get the raw `const struct device *` of the device tree generated node.
-                    pub unsafe fn get_instance_raw() -> *const crate::raw::device {
-                        &crate::raw::#rawdev
-                    }
-                    #[allow(dead_code)]
-                    pub(crate) unsafe fn get_static_raw() -> &'static #static_type {
-                        &STATIC
-                    }
+                match node.get_single_string("status") {
+                    Some("okay") | Some("ok") | None => {
+                        quote! {
+                            /// Get the raw `const struct device *` of the device tree generated node.
+                            pub unsafe fn get_instance_raw() -> *const crate::raw::device {
+                                &crate::raw::#rawdev
+                            }
+                            #[allow(dead_code)]
+                            pub(crate) unsafe fn get_static_raw() -> &'static #static_type {
+                                &STATIC
+                            }
 
-                    static UNIQUE: crate::device::Unique = crate::device::Unique::new();
-                    static STATIC: #static_type = #static_type::new();
-                    pub fn get_instance() -> Option<#device_id> {
-                        unsafe {
-                            let device = get_instance_raw();
-                            #device_id::new(&UNIQUE, &STATIC, device)
+                            static UNIQUE: crate::device::Unique = crate::device::Unique::new();
+                            static STATIC: #static_type = #static_type::new();
+                            pub fn get_instance() -> Option<#device_id> {
+                                unsafe {
+                                    let device = get_instance_raw();
+                                    #device_id::new(&UNIQUE, &STATIC, device)
+                                }
+                            }
                         }
+                    }
+                    _ => {
+                        quote! {}
                     }
                 }
             }


### PR DESCRIPTION
Code generated for disabled nodes produces Rust compiler errors, thus
we must not generate getters for unavailable nodes.

Fixes building for RP2350 (otherwise passes and works).

> A node is considered enabled if its status property
> is either ``"okay"`` or not defined
> For backwards compatibility, the value ``"ok"``
> is treated the same as ``"okay"``

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
