### PR TITLE
dt-rust.yaml: Add STM32 flash controller

### DIFF
--- a/dt-rust.yaml
+++ b/dt-rust.yaml
@@ -37,6 +37,7 @@
         - "nordic,nrf51-flash-controller"
         - "raspberrypi,pico-flash-controller"
         - "zephyr,sim-flash"
+        - "st,stm32-flash-controller"
       level: 0
   actions:
     - !Instance


### PR DESCRIPTION
Augment flash controllers with their instance on STM32

[davidb: minor fixups for 'main']