### PR TITLE
ci: Only try to push to s3 for same-repo pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -81,7 +81,8 @@ jobs:
     runs-on: ubuntu-24.04
     if: |
       github.event_name == 'pull_request' &&
-      github.repository == 'zephyrproject-rtos/zephyr-lang-rust'
+      github.repository == 'zephyrproject-rtos/zephyr-lang-rust' &&
+      github.event.pull_request.repo.full_name == github.repository
 
     steps:
       - name: Download documentation artifact


### PR DESCRIPTION
When running CI on pull requests, the S3 keys needed to push doc changes are only accessible when the pull request comes from the same repo as the project repo.  If it is from a clone, these are not available, and the push fails.

Work around this by correctly detecting this case, and avoiding the s3 push in these instances.

As we get more and more outside contributions, this will need to be revisited, possibly with a separate workflow that runs in a different context and has the keys available.