### PR TITLE
cmake: Add ZEPHYR_BASE environnement variable to sample-cargo-config.toml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ INCLUDE_DEFINES = \"${include_defines}\"
 WRAPPER_FILE = \"${WRAPPER_FILE}\"
 BINARY_DIR_INCLUDE_GENERATED = \"${BINARY_DIR_INCLUDE_GENERATED}\"
 DT_AUGMENTS = \"${DT_AUGMENTS}\"
+ZEPHYR_BASE = \"${ZEPHYR_BASE}\"
 
 [patch.crates-io]
 ${config_paths}


### PR DESCRIPTION
In order to use a Jetbrains IDE, I've followed the step bellows :
- Open Clion and configure Zephyr integration like for a c project
- Add Zephyr rust lang support and compile the project at least once 
- Install rust extension
- Rust extension sync fails due to missing zephyr crate
- Symlink sample-cargo-config.toml to .cargo config : `ln -s ../build/rust/sample-cargo-config.toml .cargo/config.toml`
- Sync fails due to missing `ZEPHYR_BASE` environnement variable (https://github.com/zephyrproject-rtos/zephyr-lang-rust/blob/main/zephyr-sys/build.rs#L30)
```
error: failed to run custom build command for `zephyr-sys v0.1.0 (/home/denisd3d/zephyrproject/modules/lang/rust/zephyr-sys)`
Caused by:
  process didn't exit successfully: `/home/denisd3d/zephyrproject/mfrc522test/build/rust/target/debug/build/zephyr-sys-9bae334ee684fef7/build-script-build` (exit status: 1)
  --- stdout
  Clang version: ClangVersion { parsed: Some((20, 1)), full: "clang version 20.1.6 (Fedora 20.1.6-1.fc42)" }
  --- stderr
  Error: environment variable not found
  Stack backtrace:
     0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
               at /home/denisd3d/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.98/src/backtrace.rs:27:14
     1: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
               at /home/denisd3d/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:2050:27
     2: build_script_build::main
               at ./build.rs:30:23
```

This PR add `ZEPHYR_BASE` environment variable to the generated sample-cargo-config.toml.
With it, Jetbrains rust extension successfully sync and provide basic completions.