### PR TITLE
dt-rust: Fix "Root" node detection

### DIFF
--- a/dt-rust.yaml
+++ b/dt-rust.yaml
@@ -66,6 +66,7 @@
 
 # Generate a pseudo node that matches all of the labels across the tree with their nodes.
 - name: labels
-  rules: !Root
+  rules:
+    - !Root
   actions:
     - !Labels


### PR DESCRIPTION
The labels node should occur only at the root node in the Rust-converted devicetree.  However, when translating the format of the yaml file to use explicit types, the rule for this node didn't end up in an array. It isn't clear why this doesn't generate an error, but making it an explicit array does fix the issue.

Without this fix, the devicetree.rs that is generated has a duplicate copy of the labels module under every node.  This fixes it to only occur at the top level.

Fixes: #113