### PR TITLE
zephyr-build: Allow kconfig entries with a value of zero

### DIFF
--- a/zephyr-build/src/lib.rs
+++ b/zephyr-build/src/lib.rs
@@ -54,7 +54,7 @@ pub fn build_kconfig_mod() {
 
     // The assumption is that hex values are unsigned, and decimal are signed.
     let config_hex = Regex::new(r"^(CONFIG_.*)=(0x[0-9a-fA-F]+)$").unwrap();
-    let config_int = Regex::new(r"^(CONFIG_.*)=(-?[1-9][0-9]*)$").unwrap();
+    let config_int = Regex::new(r"^(CONFIG_.*)=(-?[1-9][0-9]*|0)$").unwrap();
     // It is unclear what quoting might be used in the .config.
     let config_str = Regex::new(r#"^(CONFIG_.*)=(".*")$"#).unwrap();
     let gen_path = Path::new(&outdir).join("kconfig.rs");


### PR DESCRIPTION
The regex for matching numeric Kconfig values would match either numbers starting with 0x for hex, or a non-zero digit. This rejected values that were just zero.  Allow this explicitly in the regex.