### PR TITLE
tests: samples: use explicit SoC qualifiers for RISC-V boards

### DIFF
--- a/samples/async-philosophers/sample.yaml
+++ b/samples/async-philosophers/sample.yaml
@@ -12,8 +12,8 @@ common:
   platform_allow:
     - qemu_cortex_m0
     - qemu_cortex_m3
-    - qemu_riscv32
-    - qemu_riscv64
+    - qemu_riscv32/qemu_virt_riscv32
+    - qemu_riscv64/qemu_virt_riscv64
     - nrf52840dk/nrf52840
 tests:
   sample.rust.work-philosopher:

--- a/samples/bench/sample.yaml
+++ b/samples/bench/sample.yaml
@@ -13,8 +13,8 @@ common:
   platform_allow:
     - qemu_cortex_m0
     - qemu_cortex_m3
-    - qemu_riscv32
-    - qemu_riscv64
+    - qemu_riscv32/qemu_virt_riscv32
+    - qemu_riscv64/qemu_virt_riscv64
     - nrf52840dk/nrf52840
 tests:
   sample.rust/bench.plain:

--- a/samples/blinky/sample.yaml
+++ b/samples/blinky/sample.yaml
@@ -6,8 +6,8 @@ common:
   platform_allow:
     - qemu_cortex_m0
     - qemu_cortex_m3
-    - qemu_riscv32
-    - qemu_riscv64
+    - qemu_riscv32/qemu_virt_riscv32
+    - qemu_riscv64/qemu_virt_riscv64
     - nrf52840dk/nrf52840
 tests:
   sample.rust.basic.blinky:

--- a/samples/embassy/sample.yaml
+++ b/samples/embassy/sample.yaml
@@ -12,8 +12,8 @@ common:
   platform_allow:
     - qemu_cortex_m0
     - qemu_cortex_m3
-    - qemu_riscv32
-    - qemu_riscv64
+    - qemu_riscv32/qemu_virt_riscv32
+    - qemu_riscv64/qemu_virt_riscv64
     - nrf52840dk/nrf52840
 tests:
   sample.rust.embassyhello:

--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -12,8 +12,8 @@ common:
   platform_allow:
     - qemu_cortex_m0
     - qemu_cortex_m3
-    - qemu_riscv32
-    - qemu_riscv64
+    - qemu_riscv32/qemu_virt_riscv32
+    - qemu_riscv64/qemu_virt_riscv64
     - nrf52840dk/nrf52840
 tests:
   sample.rust.helloworld:

--- a/samples/philosophers/sample.yaml
+++ b/samples/philosophers/sample.yaml
@@ -14,8 +14,8 @@ common:
   platform_allow:
     - qemu_cortex_m0
     - qemu_cortex_m3
-    - qemu_riscv32
-    - qemu_riscv64
+    - qemu_riscv32/qemu_virt_riscv32
+    - qemu_riscv64/qemu_virt_riscv64
     - nrf52840dk/nrf52840
 tests:
   sample.rust.philosopher.semaphore:

--- a/tests/time/testcase.yaml
+++ b/tests/time/testcase.yaml
@@ -3,8 +3,8 @@ common:
   platform_allow:
     - qemu_cortex_m0
     - qemu_cortex_m3
-    - qemu_riscv32
-    - qemu_riscv64
+    - qemu_riscv32/qemu_virt_riscv32
+    - qemu_riscv64/qemu_virt_riscv64
     - nrf52840dk/nrf52840
 tests:
   test.rust.time:

--- a/tests/timer/testcase.yaml
+++ b/tests/timer/testcase.yaml
@@ -3,8 +3,8 @@ common:
   platform_allow:
     - qemu_cortex_m0
     - qemu_cortex_m3
-    - qemu_riscv32
-    - qemu_riscv64
+    - qemu_riscv32/qemu_virt_riscv32
+    - qemu_riscv64/qemu_virt_riscv64
     - nrf52840dk/nrf52840
 tests:
   test.rust.timer:


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/pull/99767 twister error. Only should be merged when the other is.