### PR TITLE
docs: Document how to generate project specific Rust documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,3 +151,23 @@ Other functionality
 
 Access to other functionality within zephyr is a work-in-progress, and this document will be updated
 as that is done.
+
+
+Generating board specific Rust documentation
+********************
+
+Traits are used to augment the devices in the devicetree representation (see dt-rust.yaml).
+These traits simplify and provide a safe way of interacting with the device.
+
+The devicetree differs by board and project configuration, so you might want to generate the documentation
+for your board and project configuration.
+To build documentation for a specific board and project configuration, use the following command:
+
+.. code-block:: console
+
+   west build -t rustdoc -b ${BOARD} ${MY_PROJECT_APPLICATION}
+
+This will generate the rust documentation and you will find the root of the documentation at ``build/rust/target/${RUST_TARGET}/doc/rustapp/index.html``.
+
+You'll find the devicetree documentation in ``build/rust/target/${RUST_TARGET}/doc/zephyr/devicetree/index.html``
+alongside the documentation of other crates included in your project.


### PR DESCRIPTION
Noticed the `rustdoc` CMake target but had to dig a bit to figure out how to build the Rust docs for my project & board.