### PR TITLE
enable NXP FRDM-MCXA156 board

### DIFF
--- a/ci-manifest.yml
+++ b/ci-manifest.yml
@@ -19,5 +19,6 @@ manifest:
         name-allowlist:
           - cmsis      # required by the ARM port
           - cmsis_6    # required by the ARM port
+          - hal_nxp    # required by NXP boards (e.g. frdm_mcxa156)
           - hal_nordic # required by the custom_plank board (Nordic based)
           - hal_stm32  # required by the nucleo_f302r8 board (STM32 based)

--- a/dt-rust.yaml
+++ b/dt-rust.yaml
@@ -38,6 +38,7 @@
         - "raspberrypi,pico-flash-controller"
         - "zephyr,sim-flash"
         - "st,stm32-flash-controller"
+        - "nxp,msf1"
       level: 0
   actions:
     - !Instance

--- a/etc/platforms.txt
+++ b/etc/platforms.txt
@@ -3,3 +3,4 @@
 -p qemu_riscv32
 -p qemu_riscv64
 -p m2gl025_miv
+-p frdm_mcxa156/mcxa156

--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -15,6 +15,7 @@ common:
     - qemu_riscv32
     - qemu_riscv64
     - nrf52840dk/nrf52840
+    - frdm_mcxa156/mcxa156
 tests:
   sample.rust.helloworld:
     tags: introduction


### PR DESCRIPTION
1. Add support for the NXP MSF1 flash controller compatible string to the devicetree Rust bindings generator.
2. Add the NXP FRDM-MCXA156 board to the list of platforms supported by the hello_world Rust sample.
3. Add the NXP FRDM-MCXA156 board to the platforms.txt file.
4. Add the hal_nxp module to the name-allowlist in the CI manifest to support NXP boards such as the FRDM-MCXA156.

run log:
```
*** Booting Zephyr OS build v4.3.0-3373-g6c410584dd64 ***
[00:00:00.000,173] <inf> rust: rustapp: Hello world from Rust on frdm_mcxa156
```