### PR TITLE
Add ZEPHYR_BASE to the env variables set in SAMPLE_CARGO_CONFIG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ target = \"${RUST_TARGET}\"
 target-dir = \"${CARGO_TARGET_DIR}\"
 
 [env]
+ZEPHYR_BASE = \"${ZEPHYR_BASE}\"
 BUILD_DIR = \"${CMAKE_CURRENT_BINARY_DIR}\"
 DOTCONFIG = \"${DOTCONFIG}\"
 ZEPHYR_DTS = \"${ZEPHYR_DTS}\"


### PR DESCRIPTION
This fixes rust-analyzer puking when processing  `zephyr-sys/build.rs` because of
```rust
│     // And get the root of the zephyr tree.
      let zephyr_base = env::var("ZEPHYR_BASE")?;
```
