### PR TITLE
zephyr-sys: Update bindgen to 0.72.1 for LLVM 22 compatibility

### DIFF
--- a/zephyr-sys/Cargo.toml
+++ b/zephyr-sys/Cargo.toml
@@ -14,5 +14,5 @@ Zephyr low-level API bindings.
 # used by the core Zephyr tree, but are needed by zephyr applications.
 [build-dependencies]
 anyhow = "1.0"
-bindgen = { version = "0.70.1", features = ["experimental"] }
+bindgen = { version = "0.72.1", features = ["experimental"] }
 # zephyr-build = { version = "0.1.0", path = "../zephyr-build" }


### PR DESCRIPTION
Bindgen 0.70.1 generates opaque 1-byte structs (`_address: u8`) for all Zephyr kernel types (k_sem, k_mutex, k_thread, device, etc.) when built with LLVM/Clang 22.  This causes compile-time size assertion overflows for every affected struct.

The root cause is an LLVM 22 change (llvm/llvm-project#147835) that made `clang_getTypeDeclaration()` return the forward declaration cursor instead of the definition cursor for types whose definition is separate from their forward declaration.  Bindgen 0.70.1 then sees `is_definition() == false`, treats the struct as a forward declaration with no fields, and emits an opaque type.

This was reported as rust-lang/rust-bindgen#3264 and fixed in bindgen 0.72.1 via rust-lang/rust-bindgen#3278, which makes `Type::declaration()` follow through to the definition.