### PR TITLE
Add design docs for primary crates and dt_cfgs README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,19 @@ For example:
    #[cfg(not(CONFIG_SCHED_DUMB))]
    other_declaration;
 
+Devicetree path settings
+------------------------
+
+Devicetree node paths can also be exported as ``cfg`` values:
+
+.. code-block:: rust
+
+   fn main() {
+       zephyr_build::dt_cfgs();
+   }
+
+This makes paths such as ``dt = "aliases::led0"`` available to ``#[cfg(...)]``.
+
 Other Kconfig settings
 ----------------------
 

--- a/zephyr-build/DESIGN.md
+++ b/zephyr-build/DESIGN.md
@@ -1,0 +1,332 @@
+# zephyr-build Design
+
+## Purpose
+
+`zephyr-build` is the host-side build support crate for the Rust-on-Zephyr stack. It is not a
+runtime crate. Its responsibility is to read build artifacts produced by Zephyr's CMake flow and
+turn them into Rust-visible configuration and reflection data.
+
+Today it serves two main roles:
+
+- expose Zephyr Kconfig state to Rust build scripts and generated Rust modules;
+- parse Zephyr's finalized devicetree outputs and generate Rust code plus `cfg(...)` markers from
+  them.
+
+This crate is consumed from `build.rs`, primarily by the `zephyr` crate itself, and in smaller ways
+by downstream application crates.
+
+## Source Layout
+
+- `src/lib.rs`: public entry points used from build scripts.
+- `src/devicetree.rs`: internal model for the parsed devicetree plus shared traversal logic.
+- `src/devicetree/parse.rs`: pest-based parser for Zephyr's generated `zephyr.dts`.
+- `src/devicetree/dts.pest`: grammar for the supported DTS subset.
+- `src/devicetree/ordmap.rs`: parser for `devicetree_generated.h` to recover Zephyr node ordinals.
+- `src/devicetree/output.rs`: Rust code generation and `cfg` emission for the parsed tree.
+- `src/devicetree/augment.rs`: YAML-driven augmentation system that adds higher-level generated
+  APIs to matching nodes.
+
+## Position in the Build
+
+The surrounding design is driven by Zephyr's CMake build.
+
+1. CMake configures Zephyr and produces `.config`, `zephyr.dts`, and
+   `include/generated/zephyr/devicetree_generated.h`.
+2. CMake invokes Cargo with environment variables such as `DOTCONFIG`, `ZEPHYR_DTS`,
+   `BINARY_DIR_INCLUDE_GENERATED`, and `DT_AUGMENTS`.
+3. `zephyr/build.rs` calls:
+   - `zephyr_build::export_bool_kconfig()`
+   - `zephyr_build::build_kconfig_mod()`
+   - `zephyr_build::build_dts()`
+4. The `zephyr` crate then includes generated `kconfig.rs` and `devicetree.rs` from `OUT_DIR`.
+5. Downstream application build scripts can also call lighter-weight helpers such as
+   `export_bool_kconfig()` or `dt_cfgs()` to make the same Zephyr configuration visible in their own
+   crates.
+
+`zephyr-build` therefore acts as the bridge from Zephyr-generated files into Rust compile-time
+state.
+
+## Public API Model
+
+The public surface is intentionally small and build-script oriented.
+
+- `export_bool_kconfig()`: emits `cargo:rustc-cfg=CONFIG_...` lines for boolean Kconfig entries.
+- `build_kconfig_mod()`: writes `OUT_DIR/kconfig.rs` containing Rust constants for numeric and
+  string-like Kconfig values.
+- `build_dts()`: parses Zephyr devicetree outputs and writes `OUT_DIR/devicetree.rs`.
+- `dt_cfgs()`: emits `cargo:rustc-cfg=dt="..."` markers for devicetree node paths and selected
+  phandle-style property paths.
+- `has_rustfmt()`: helper used internally to decide whether generated code should be formatted.
+
+This keeps the crate focused on generation rather than on providing a reusable runtime abstraction.
+
+## Kconfig Pipeline
+
+Kconfig support is file-based and intentionally simple.
+
+### Boolean Export
+
+`export_bool_kconfig()` reads the Zephyr `.config` file named by `DOTCONFIG` and matches lines of
+the form `CONFIG_FOO=y`. For every such line it emits a Cargo directive:
+
+- `cargo:rustc-cfg=CONFIG_FOO`
+
+This lets both `zephyr` and user crates write conditional compilation against Zephyr Kconfig
+booleans.
+
+### Generated Value Module
+
+`build_kconfig_mod()` also reads `DOTCONFIG`, but instead of emitting `cfg`s it generates a Rust
+module file.
+
+It recognizes:
+
+- hex values, emitted as `usize`;
+- decimal values, emitted as `isize`;
+- quoted strings, emitted as `&str`.
+
+The resulting file is included by `zephyr::kconfig`.
+
+### Tradeoff
+
+This Kconfig extraction is pragmatic rather than type-perfect. It infers Rust types from textual
+shape instead of Kconfig schema information. That keeps the implementation simple and independent of
+Zephyr internals, but it means the generated types are only an approximation of the original Kconfig
+types.
+
+## Devicetree Pipeline
+
+The devicetree side is more ambitious. It combines two Zephyr outputs because neither one is
+sufficient on its own.
+
+### Inputs
+
+- `zephyr.dts`: the finalized, merged devicetree in DTS syntax.
+- `devicetree_generated.h`: generated C macros that include node ordinal information not available
+  in the DTS text.
+
+### Why Both Inputs Are Needed
+
+The DTS file is easier to parse and preserves the hierarchical structure, properties, strings,
+bytes, and phandle references in a readable form.
+
+The generated header is used to recover the Zephyr "ORD" number for each node. Those ordinals are
+important because Zephyr device instances are indexed by them, and downstream Rust code needs to be
+able to connect a devicetree node to symbols such as `__device_dts_ord_N`.
+
+### Internal Representation
+
+`DeviceTree::new()` builds an in-memory tree of:
+
+- `Node`: name, full path, route, ordinal, labels, properties, children, and parent link;
+- `Property`: property name plus one or more parsed values;
+- `Value`: words, bytes, strings, or phandles;
+- `Word`: either numbers or phandle references.
+
+Phandles are initially unresolved by label name and then fixed up in a second pass once all labels
+have been collected.
+
+## Devicetree Parsing Strategy
+
+The DTS parser is deliberately narrow. It does not aim to implement arbitrary devicetree syntax.
+Instead, it parses the subset expected from Zephyr's generated `zephyr.dts`.
+
+Key characteristics of the parser:
+
+- it uses a pest grammar instead of ad hoc string parsing;
+- it supports labels, nested nodes, properties, strings, number lists, byte arrays, and phandles;
+- it assumes the Zephyr-generated file shape rather than the full generality of DTS source files.
+
+This is a conscious design choice. The crate is not a general-purpose DTS parser; it is a parser for
+Zephyr's post-processed output.
+
+## Ordinal Recovery
+
+`ordmap.rs` scans `devicetree_generated.h` for pairs of macros:
+
+- `DT_..._PATH`
+- `DT_..._ORD`
+
+It correlates them by macro stem and builds a `BTreeMap<String, usize>` from devicetree path to
+ordinal.
+
+That map is then consulted during DTS parsing so each parsed node can be assigned the Zephyr ordinal
+that higher-level generated APIs depend on.
+
+## Generated Rust Devicetree Model
+
+`build_dts()` eventually emits `devicetree.rs`, which `zephyr::devicetree` includes.
+
+The generated code mirrors the devicetree hierarchy as nested Rust modules:
+
+- each node becomes a submodule;
+- each node module exposes `ORD`;
+- simple numeric properties become `pub const` values when possible;
+- simple phandle properties become modules that re-export the referenced target node;
+- more complex properties fall back to debug-style constants or raw-property output from
+  augmentations.
+
+The output is meant to make devicetree structure navigable from Rust source rather than to exactly
+mirror every C macro in Zephyr's C headers.
+
+## Augmentation System
+
+The augmentation system is the most specialized part of the crate.
+
+### Motivation
+
+A plain structural reflection of the devicetree is not enough for ergonomic use. Some nodes need
+higher-level generated APIs that know how to construct Rust device wrapper types from devicetree
+metadata.
+
+Rather than hard-coding all such logic directly into the parser, `zephyr-build` uses a YAML-driven
+augmentation layer.
+
+### Model
+
+An augmentation file contains a list of `Augmentation` entries, each with:
+
+- `rules`: predicates deciding which nodes match;
+- `actions`: code generators run for matching nodes.
+
+Rules currently include:
+
+- property presence;
+- compatible string checks at the current node or ancestor levels;
+- boolean combinations;
+- root matching.
+
+Actions currently include:
+
+- `Instance`: generate `get_instance()`-style constructors for Rust device wrapper types;
+- `Labels`: generate a synthetic `labels` module mapping every devicetree label to its node module;
+- `RawProperties`: emit static raw property data for runtime access.
+
+### Data Sources for `Instance`
+
+`Instance` generation can derive the underlying raw Zephyr device from:
+
+- the current node itself;
+- an ancestor node;
+- a phandle property on the current node.
+
+This allows the generated code to cover patterns such as:
+
+- controller nodes that directly correspond to a Zephyr device;
+- child nodes whose device comes from a parent controller;
+- specifier nodes such as GPIO consumers that refer to a controller by phandle plus cell
+  arguments.
+
+### Current Configuration
+
+The top-level `dt-rust.yaml` file in this repository uses this mechanism to add support for:
+
+- GPIO controllers;
+- GPIO-backed LED nodes;
+- flash controllers;
+- flash partitions;
+- raw property reflection;
+- global label aliases.
+
+This keeps the generic parsing engine separate from board- and device-family-specific policy.
+
+## `cfg(dt = "...")` Support
+
+`dt_cfgs()` emits Cargo `rustc-cfg` directives for devicetree node paths so downstream crates can
+conditionally compile against the presence of nodes.
+
+Examples of the intended shape include paths such as:
+
+- `dt = "aliases::led0"`
+- `dt = "soc::gpio_40014000"`
+
+It also emits label-based paths under `dt = "labels::..."`.
+
+This is intentionally lighter-weight than generating the full `devicetree.rs` module for every
+consumer crate. It gives applications a way to key conditional compilation off the same devicetree
+without needing to parse it themselves.
+
+## Formatting Strategy
+
+When generating Rust source, `build_dts()` prefers to run `rustfmt` if it is available on the host.
+If `rustfmt` is absent, it writes the token stream directly.
+
+This is a convenience feature rather than a correctness requirement. The generated code should still
+be usable without `rustfmt`, but formatted output is easier to inspect and document.
+
+## Relationship to Other Crates
+
+- `zephyr-sys` is about raw C ABI bindings.
+- `zephyr-build` is about compile-time reflection from Zephyr build artifacts.
+- `zephyr` consumes both:
+  - `zephyr-sys` for runtime FFI;
+  - `zephyr-build` for generated `kconfig` and `devicetree` modules.
+
+Downstream application crates may also depend on `zephyr-build` directly in `build-dependencies`
+when they need their own Kconfig- or devicetree-driven conditional compilation.
+
+## Current Constraints and Tradeoffs
+
+### Host-Build Assumptions
+
+The crate assumes it is running inside a Zephyr/CMake-orchestrated build with the expected
+environment variables already set. It is not designed to discover those artifacts independently.
+
+### Narrow DTS Support
+
+The pest grammar intentionally supports only the subset of DTS syntax seen in Zephyr's generated
+output. That reduces complexity, but it means the parser is not suitable as a general DTS frontend.
+
+### Approximate Kconfig Typing
+
+Kconfig value typing is inferred from text, not from Kconfig metadata. This is good enough for
+current use, but it is not semantically exact.
+
+### Generated API Is Configuration-Specific
+
+Both generated modules depend on the active board and configuration. The resulting Rust API is
+therefore not globally stable across all Zephyr builds.
+
+### Augmentation Policy Lives Outside Core Parsing
+
+The augmentation system keeps policy out of the parser, which is good for modularity, but it also
+means higher-level device support depends on external YAML configuration and convention-driven code
+generation.
+
+### Tight Coupling to `zephyr`
+
+Some generated augmentation code assumes specific runtime types and constructors exist in the
+`zephyr` crate, such as `crate::device::gpio::Gpio` and `crate::device::flash::FlashPartition`.
+That makes the output practical for this repository, but not yet a general-purpose devicetree code
+generation framework for arbitrary downstream crates.
+
+## Extending the Crate
+
+Typical extension points are:
+
+1. expand Kconfig extraction rules in `src/lib.rs`;
+2. broaden the DTS grammar if Zephyr's generated DTS requires new constructs;
+3. extend the internal devicetree model if new property forms need richer handling;
+4. add new `Rule`, `Action`, or `ArgInfo` variants for augmentation-driven code generation;
+5. add new entries to `dt-rust.yaml` when supporting additional Zephyr device classes in the
+   generated Rust API.
+
+The current design expects most device-specific growth to happen through augmentation rules and YAML
+configuration rather than by teaching the core parser about every device family.
+
+## Non-Goals
+
+From the current source, `zephyr-build` is not trying to:
+
+- replace Zephyr's own CMake, Kconfig, or devicetree tooling;
+- parse arbitrary DTS inputs from arbitrary ecosystems;
+- provide a stable runtime API;
+- generate fully generic device wrapper code independent of the `zephyr` crate;
+- infer complete semantic meaning for all devicetree bindings without extra augmentation data.
+
+## Summary
+
+`zephyr-build` is the build-time reflection layer for Rust on Zephyr. It reads Zephyr-generated
+configuration artifacts, turns Kconfig into Rust `cfg`s and constants, turns devicetree outputs into
+a Rust module tree plus `cfg(dt = "...")` markers, and uses a YAML-driven augmentation system to add
+the device-specific generated APIs that the higher-level `zephyr` crate depends on.

--- a/zephyr-macros/DESIGN.md
+++ b/zephyr-macros/DESIGN.md
@@ -1,0 +1,228 @@
+# zephyr-macros Design
+
+## Purpose
+
+`zephyr-macros` is a small proc-macro crate that currently exists to provide one user-facing
+attribute:
+
+- `#[zephyr::thread(...)]`
+
+Its role is not to implement runtime functionality itself. Instead, it generates boilerplate around
+the runtime thread support provided by the main `zephyr` crate.
+
+In other words:
+
+- `zephyr-macros` rewrites syntax;
+- `zephyr::thread` provides the actual runtime types and behavior.
+
+## Source Layout
+
+- `src/lib.rs`: proc-macro entry point and user-facing documentation for `#[thread]`.
+- `src/task.rs`: full implementation of the attribute expansion and validation logic.
+
+Despite the filename `task.rs`, the current macro is about Zephyr threads, not a general task
+system.
+
+## Public Surface
+
+The crate exposes a single attribute macro:
+
+- `thread`
+
+From a user perspective, it is re-exported by the `zephyr` crate as `#[zephyr::thread]`.
+
+The macro converts a Rust function declaration into:
+
+- a hidden renamed inner function containing the original body;
+- a public wrapper function with the original name;
+- static thread-pool and stack storage;
+- a C ABI startup shim that Zephyr can invoke as a thread entry point.
+
+## Overall Expansion Strategy
+
+The design of `#[zephyr::thread]` is to let users write something that looks like a normal Rust
+function:
+
+```rust
+#[zephyr::thread(stack_size = 1024)]
+fn worker(arg: u32) {
+    // ...
+}
+```
+
+and expand it into something callable that returns `zephyr::thread::ReadyThread`.
+
+That returned `ReadyThread` can then be started explicitly by the caller. This matches the runtime
+design in `zephyr::thread`, where threads are created in a prepared state and then started.
+
+## Attribute Arguments
+
+The macro currently supports:
+
+- `stack_size`
+- `pool_size`
+
+Both are parsed as Rust expressions via `darling`.
+
+Current behavior from the source:
+
+- `pool_size` defaults to `1`;
+- `stack_size` currently defaults to `2048`, even though the public docs say it should be required.
+
+That default is a pragmatic implementation choice rather than a final interface guarantee.
+
+## Generated Runtime Structure
+
+For each annotated function, the macro generates several internal items.
+
+### Hidden Inner Function
+
+The original function is renamed to a hidden symbol like:
+
+- `__mythread_thread`
+
+This preserves the user's function body with minimal transformation.
+
+### Argument Carrier Struct
+
+The function arguments are repackaged into a generated internal struct:
+
+- `_ZephyrInternalArgs`
+
+This allows the macro to move all arguments into Zephyr's thread startup data as one owned value.
+
+### Static Thread Pool
+
+The macro generates a static array of:
+
+- `zephyr::thread::ThreadData<_ZephyrInternalArgs>`
+
+The array size is `pool_size`. This means the attribute is not generating a single-use thread by
+default; it is generating access to a reusable pool of thread slots.
+
+### Static Stack Pool
+
+The macro also generates a matching static array of:
+
+- `zephyr::thread::ThreadStack<_ZEPHYR_INTERNAL_STACK_SIZE>`
+
+again sized by `pool_size`.
+
+### Startup Shim
+
+An `extern "C"` startup function is generated. Zephyr invokes this as the actual thread entry
+point. It:
+
+1. receives the raw startup pointer passed through Zephyr;
+2. reinterprets it as `InitData<_ZephyrInternalArgs>`;
+3. extracts the stored argument struct;
+4. calls the hidden inner Rust function with those arguments.
+
+This is the key bridge from Zephyr's C-style thread entry ABI into the original Rust function
+signature.
+
+### Public Wrapper Function
+
+The user's original function name is retained for a generated wrapper that:
+
+- builds `_ZephyrInternalArgs` from the user arguments;
+- calls `zephyr::thread::ThreadData::acquire(...)`;
+- returns `zephyr::thread::ReadyThread`.
+
+So the macro is effectively a constructor generator for thread instances.
+
+## Validation Rules
+
+The macro performs static validation before generating code.
+
+The current checks reject:
+
+- `async fn`
+- generic functions
+- `where` clauses
+- explicit ABI qualifiers
+- variadic functions
+- receiver arguments such as `self`
+- non-`()` / non-`!` return types
+- non-`'static` references in arguments
+- `impl Trait` in argument position
+- destructuring patterns in parameters
+
+These constraints follow from the runtime model:
+
+- thread functions need a concrete, monomorphic entry point;
+- arguments must outlive transfer into the spawned Zephyr thread;
+- Zephyr startup expects owned data, not arbitrary pattern destructuring;
+- the generated startup shim assumes a plain identifier-based argument unpacking model.
+
+## Error Handling Strategy
+
+One notable design choice is that macro failures do not simply stop expansion immediately after the
+first problem.
+
+Instead, the implementation tries to:
+
+- accumulate validation errors into a token stream;
+- still emit something structurally close to the expected output;
+- fall back to a placeholder `todo!()`-based wrapper return value when needed.
+
+This is explicitly done to improve IDE behavior. The source comments make clear that the goal is to
+preserve completion and editing support even when the input is currently invalid.
+
+That is a practical proc-macro design choice rather than a runtime concern.
+
+## Relationship to `zephyr::thread`
+
+The macro is tightly coupled to the runtime API in `zephyr::thread`.
+
+It depends directly on the existence and behavior of:
+
+- `zephyr::thread::ThreadData`
+- `zephyr::thread::ThreadStack`
+- `zephyr::thread::InitData`
+- `zephyr::thread::ReadyThread`
+- `zephyr::thread::stack_len`
+
+This means `zephyr-macros` is not a general reusable thread macro framework. It is specifically a
+syntax layer over the runtime thread model implemented in this repository.
+
+## Naming and Current Rough Edges
+
+A few implementation details in the current source are worth calling out:
+
+- `task.rs` still carries comments referring to `task` rather than `thread`;
+- the generated stack linker section currently uses a placeholder string `.noinit.TODO_STACK`;
+- the crate metadata contains `descriptions` instead of the usual `description`;
+- the user-facing docs say `stack_size` must be specified, but the implementation still provides a
+  default.
+
+These do not change the design intent, but they show the crate is still evolving.
+
+## Extending the Crate
+
+With the current structure, likely extensions would be:
+
+1. add more validation and better diagnostics to `#[thread]`;
+2. tighten the interface so documented requirements like mandatory `stack_size` match the
+   implementation;
+3. generate richer configuration options such as thread priority or options flags;
+4. add additional proc macros only when they have a clear runtime home in the `zephyr` crate.
+
+The current crate is intentionally minimal. It does not appear to be aiming for a broad catalog of
+macros without matching runtime support.
+
+## Non-Goals
+
+From the current source, `zephyr-macros` is not trying to:
+
+- implement runtime scheduling or thread management itself;
+- provide a general-purpose task system independent of `zephyr`;
+- support arbitrary Rust function signatures;
+- hide the Zephyr runtime model behind magical syntax.
+
+## Summary
+
+`zephyr-macros` is a thin proc-macro layer over the `zephyr::thread` runtime. Its single current
+job is to turn a restricted Rust function into the static storage, startup shim, and wrapper
+function needed to spawn Zephyr-managed threads with typed Rust arguments, while enforcing the
+signature constraints that make that transformation sound.

--- a/zephyr-sys/DESIGN.md
+++ b/zephyr-sys/DESIGN.md
@@ -1,0 +1,220 @@
+# zephyr-sys Design
+
+## Purpose
+
+`zephyr-sys` is the raw FFI layer for the Rust support in this repository. Its job is to expose a
+selected subset of Zephyr's C API to Rust with minimal policy and minimal hand-written code. The
+crate is intentionally narrow:
+
+- `zephyr-sys` generates `unsafe` bindings to Zephyr headers.
+- `zephyr` builds safer and more idiomatic Rust wrappers on top of those bindings.
+- CMake drives the build environment so the bindings match the active Zephyr board and Kconfig
+  configuration.
+
+The crate is `#![no_std]` and mostly consists of generated code included from `OUT_DIR`.
+
+## Source Layout
+
+- `build.rs`: runs `bindgen`, translates Cargo/CMake environment into clang arguments, and writes
+  generated Rust bindings plus C wrappers for static inline functions.
+- `wrapper.h`: seed header for bindgen. This chooses the Zephyr headers that define the reachable
+  API surface and adds a few helper constants/functions that bindgen would not otherwise expose.
+- `src/lib.rs`: includes generated bindings and applies a few post-generation trait impls needed by
+  the rest of the workspace.
+- `Cargo.toml`: keeps the crate small; the only runtime dependency is the generated code itself, and
+  the only explicit dependencies are build-time ones.
+
+## Build-Time Architecture
+
+The binding pipeline is controlled outside the crate by the top-level module `CMakeLists.txt`.
+
+1. CMake determines the Rust target triple from the active Zephyr architecture and ABI settings.
+2. CMake collects Zephyr include directories and compile definitions from `zephyr_interface`.
+3. CMake invokes Cargo with environment variables such as `ZEPHYR_BASE`, `INCLUDE_DIRS`,
+   `INCLUDE_DEFINES`, `WRAPPER_FILE`, `DOTCONFIG`, and `ZEPHYR_DTS`.
+4. Cargo runs `zephyr-sys/build.rs`.
+5. `build.rs` runs `bindgen` over `wrapper.h`, emits Rust bindings to `OUT_DIR/bindings.rs`, and
+   emits a generated C source file at the `WRAPPER_FILE` path for static inline wrappers.
+6. CMake compiles that generated wrapper C file into the final application along with the Rust
+   static library.
+
+This means the crate does not attempt to discover a Zephyr installation itself. It relies on the
+Zephyr CMake flow to provide a fully configured compilation environment.
+
+## Environment Contract
+
+`build.rs` currently assumes these variables are present:
+
+- `TARGET`: Rust compilation target. The script normalizes some RISC-V triples to generic clang
+  triples because libclang and Rust use different spellings.
+- `ZEPHYR_BASE`: used to add the minimal libc include path.
+- `INCLUDE_DIRS`: passed through as `-I...` arguments.
+- `INCLUDE_DEFINES`: passed through as `-D...` arguments.
+- `WRAPPER_FILE`: output path for bindgen-generated static-function wrappers.
+- `OUT_DIR`: Cargo output directory for `bindings.rs`.
+
+The crate fails fast with `unwrap()` or `?` when these values are missing. That fits the current
+design: `zephyr-sys` is not intended to be built in isolation from the surrounding Zephyr build.
+
+## API Selection Strategy
+
+The crate does not expose "all of Zephyr". The generated surface is bounded in two ways.
+
+First, `wrapper.h` constrains the parse root by including only a chosen set of headers:
+
+- kernel APIs
+- thread stack definitions
+- GPIO
+- logging
+- Bluetooth
+- flash
+- IRQ support
+
+Second, `build.rs` further constrains what bindgen emits with allowlists. The current allowlists are
+pattern-based and focus on kernel, device, GPIO, flash, logging, Bluetooth, and selected constants
+and generated device symbols.
+
+This two-stage selection is important:
+
+- adding a new header in `wrapper.h` expands the type universe bindgen can see;
+- adding a new allowlist pattern in `build.rs` expands the symbols that are actually emitted.
+
+Both usually need to change together when broadening coverage.
+
+## Why `wrapper.h` Exists
+
+`wrapper.h` is more than a convenience include file. It adapts Zephyr's headers into a shape that
+bindgen can consume reliably.
+
+### Configuration Alignment
+
+It includes `zephyr/autoconf.h` first so parsing happens under the active Kconfig configuration.
+Without this, many Zephyr declarations would not match the actual compiled system.
+
+### Macro and ABI Fixups
+
+It undefines `KERNEL` because building with `KERNEL` defined interferes with syscall-related
+declarations in a way that is not useful for Rust binding generation.
+
+It also defines `__SOFTFP__` for some Cortex-M soft-float configurations because CMSIS headers
+expect that gcc-style define.
+
+### Exporting Values Bindgen Misses
+
+Bindgen only emits simple constants reliably. `wrapper.h` therefore materializes several macro-based
+values as named `const` objects with a `ZR_` prefix, including stack layout constants, selected poll
+constants, and several GPIO flags.
+
+### Access to Macro-Only APIs
+
+Some Zephyr functionality is provided as macros rather than callable functions. `wrapper.h` adds
+small static inline adapters such as `zr_irq_lock()` and `zr_irq_unlock()` so the operations can be
+bound as normal extern functions.
+
+## Static Inline Wrapper Generation
+
+Many Zephyr APIs are exposed as `static inline` functions in headers. Rust cannot link against those
+directly because they do not exist as standalone symbols in a library.
+
+`build.rs` uses `bindgen`'s `wrap_static_fns(true)` support to generate a companion C file at the
+path provided by `WRAPPER_FILE`. That file contains exported wrapper functions such as
+`k_uptime_get__extern(...)` which call the original inline definitions. CMake then compiles that C
+file into the final build, making the functions linkable from Rust.
+
+This is a core design choice: the crate depends on generated C shims, not only generated Rust code.
+
+## Rust Crate Surface
+
+`src/lib.rs` is deliberately thin.
+
+- It applies crate-level lint suppressions that are normal for bindgen output.
+- It includes `OUT_DIR/bindings.rs`.
+- It reintroduces `Copy` and `Clone` for a small number of types where the workspace expects value
+  semantics (`z_spinlock_key`, `k_timeout_t`).
+
+The explicit `derive_copy!`/`derive_clone!` macros are a local correction after
+`.derive_copy(false)`. The current approach is conservative: bindgen is told not to mark everything
+as `Copy`, and the crate opts specific types back in by hand.
+
+## Relationship to `zephyr`
+
+The higher-level `zephyr` crate re-exports `zephyr-sys` as `zephyr::raw` and uses it to implement
+safe wrappers in modules such as `zephyr::sys`, device abstractions, synchronization, threading,
+timers, and logging.
+
+That separation of responsibilities is clear in the current codebase:
+
+- `zephyr-sys` owns fidelity to the C ABI.
+- `zephyr` owns safety, ergonomics, and Rust-side policy.
+
+## Current Constraints and Tradeoffs
+
+### Configuration-Specific Bindings
+
+The bindings are generated per build, not shipped as a fixed checked-in API. This is necessary for
+Zephyr because header contents vary with board, architecture, and Kconfig, but it also means:
+
+- docs and IDE support need the same build environment;
+- the exact Rust API may vary across applications;
+- reproducibility depends on the surrounding Zephyr configuration.
+
+### Tight Coupling to CMake
+
+The crate assumes the top-level Rust module CMake logic will provide all inputs. That keeps the
+crate simple, but makes standalone Cargo usage impractical today.
+
+### Pattern-Based Coverage
+
+Allowlist patterns are easy to maintain, but they are approximate. A broad pattern can expose more
+surface than intended, while a narrow pattern can silently omit required symbols until a consumer
+hits a missing binding.
+
+### Manual Constant Adapters
+
+The `ZR_` constants are pragmatic and explicit, but they create a second namespace that higher-level
+code must know about. This is acceptable for now, but it is a maintenance point whenever new macro
+constants are needed.
+
+### Selective Trait Repair
+
+The manual `Copy`/`Clone` restoration in `src/lib.rs` is safe only as long as those C types remain
+plain value types. This is a reasonable tradeoff, but additions should be reviewed carefully rather
+than expanded mechanically.
+
+## Extending the Crate
+
+When adding more raw Zephyr APIs, the expected workflow is:
+
+1. Add the necessary header include to `wrapper.h` if bindgen cannot already reach the declarations.
+2. Add or adjust allowlist patterns in `build.rs`.
+3. If the target API is a macro or a complex constant, add an adapter in `wrapper.h`.
+4. If the target API is a `static inline` function, rely on the generated wrapper C output.
+5. Add safe or thin wrappers in `zephyr`, not in `zephyr-sys`, unless the change is strictly about
+   raw binding fidelity.
+
+Longer term, the intended direction is to make the raw binding surface extensible from an
+application that depends on `zephyr`, rather than requiring every new binding need to be added in
+this crate ahead of time. That would let applications request additional headers, symbols, or
+adapter glue as part of their own build.
+
+That problem is currently unsolved. It is challenging because the binding set is generated inside
+the Zephyr/CMake-driven build environment, while the `zephyr` crate is consumed from downstream
+Cargo applications that do not currently have a supported mechanism to extend `zephyr-sys`
+generation in a coordinated, reproducible way.
+
+## Non-Goals
+
+From the current source, `zephyr-sys` is not trying to:
+
+- present an idiomatic Rust API;
+- guarantee a stable, board-independent surface;
+- replace the higher-level `zephyr` crate;
+- build independently of the Zephyr CMake environment;
+- hand-model the entire Zephyr API.
+
+## Summary
+
+`zephyr-sys` is a generated, configuration-specific FFI crate. Its design is centered on using
+Zephyr's existing configured C build as the source of truth, then applying a small amount of
+hand-written adaptation in `wrapper.h` and `src/lib.rs` to bridge the gaps that bindgen alone does
+not cover.

--- a/zephyr/DESIGN.md
+++ b/zephyr/DESIGN.md
@@ -1,0 +1,469 @@
+# zephyr Design
+
+## Purpose
+
+`zephyr` is the main Rust runtime crate for applications that run on top of the Zephyr RTOS. It is
+the layer that turns:
+
+- raw C bindings from `zephyr-sys`;
+- build-time reflection from `zephyr-build`;
+- Zephyr kernel and driver concepts;
+
+into Rust APIs that are safer and more idiomatic, while still staying recognizably close to Zephyr.
+
+The crate is `#![no_std]`. It is designed to support both minimal no-alloc systems and richer
+systems with `CONFIG_RUST_ALLOC`.
+
+## Design Goals
+
+From the source, the crate is trying to balance several competing goals:
+
+- preserve access to Zephyr concepts rather than hiding the RTOS behind an unrelated abstraction;
+- move as much unsafety as possible into library internals;
+- support static, linker-visible kernel objects in a way that matches Zephyr's object model;
+- support targets that may lack native atomic instructions;
+- allow generated build-specific reflection of Kconfig and devicetree state;
+- optionally layer in allocation, timers, work queues, logging, and Embassy integration.
+
+This is not a port of `std`, and it is not a purely "Rust-native RTOS". It is a Rust-facing Zephyr
+support crate.
+
+## High-Level Architecture
+
+The crate is built in layers.
+
+### 1. Build-Time Reflection
+
+`build.rs` invokes `zephyr-build` to generate:
+
+- `kconfig.rs`, included as `zephyr::kconfig`;
+- `devicetree.rs`, included as `zephyr::devicetree`.
+
+This makes the active Zephyr build configuration visible to Rust code.
+
+### 2. Raw FFI Layer
+
+`zephyr::raw` simply re-exports `zephyr-sys`.
+
+This is the escape hatch for direct access to generated C bindings. It remains unsafe and close to
+the underlying ABI.
+
+### 3. Thin Safe Wrappers
+
+`zephyr::sys` provides low-level wrappers over `zephyr-sys` that remove `unsafe` from common use
+but intentionally preserve Zephyr semantics as much as possible.
+
+Examples:
+
+- `sys::sync::Semaphore`, `Mutex`, `Condvar`
+- `sys::queue::Queue`
+- `sys::thread`
+- `sys::critical` for the `critical-section` crate integration
+
+### 4. Higher-Level Rust APIs
+
+Above `sys`, the crate builds more idiomatic Rust interfaces:
+
+- `sync::Mutex`, `Condvar`, `SpinMutex`, channels, atomics, `Arc`
+- `time::{Duration, Instant, Timeout}`
+- typed device wrappers under `device`
+- higher-level thread helpers in `thread`
+- timers in `timer`
+- work queues in `work`
+- logging integration in `logging`
+
+These are the intended main user-facing APIs.
+
+## Module Map
+
+The major modules break down as follows:
+
+- `lib.rs`: crate root, feature gating, generated module inclusion, panic handler, raw re-export.
+- `error.rs`: Zephyr errno-to-`Result` mapping.
+- `time.rs`: Zephyr-oriented time types and timeout conversions.
+- `object.rs`: kernel-object and fixed-address infrastructure, plus `kobj_define!`.
+- `sys/`: safe but low-level wrappers over Zephyr primitives.
+- `sync/`: higher-level synchronization primitives modeled after `std` and `crossbeam`.
+- `device/`: typed wrappers around Zephyr devices and devicetree-generated constructors.
+- `thread.rs`: higher-level thread-pool style and reusable-thread support.
+- `printk.rs`: formatting-to-console support.
+- `logging/`: `log` crate backend integration.
+- `timer.rs`: higher-level wrapper over `k_timer`.
+- `work.rs`: work queues, work items, and signal support.
+- `embassy/`: feature-gated Embassy executor/time integration.
+- `alloc_impl.rs`: global allocator when `CONFIG_RUST_ALLOC` is enabled.
+- `simpletls.rs`: lightweight thread-local mapping helper used by work queues.
+
+## Generated Configuration Reflection
+
+The crate directly includes build-generated modules:
+
+- `zephyr::kconfig`
+- `zephyr::devicetree`
+
+This is a central part of the design, not an add-on. Many APIs depend on build-time configuration,
+and device access is meant to flow through generated devicetree modules such as label aliases and
+instance constructors.
+
+The tradeoff is that part of the crate's visible API is configuration-specific. Docs and code
+completion are therefore most useful when generated for a concrete build.
+
+## Relationship to `zephyr-sys`
+
+`zephyr-sys` owns raw ABI fidelity.
+
+`zephyr` uses it in three ways:
+
+- direct re-export as `zephyr::raw`;
+- thin wrapping in `zephyr::sys`;
+- implementation detail beneath higher-level abstractions.
+
+The intent is clear in the source:
+
+- use `zephyr::raw` when direct bindings are unavoidable;
+- prefer `zephyr::sys` for close-to-Zephyr but safe access;
+- prefer `sync`, `device`, `timer`, `work`, and related modules for regular Rust code.
+
+## Kernel Object Model
+
+One of the biggest design choices in the crate is how it handles Zephyr kernel objects.
+
+Zephyr expects many objects to be:
+
+- statically allocated;
+- visible to the kernel object system and linker sections;
+- not moved after initialization;
+- in some cases accessible from userspace only if specially declared.
+
+Rust's normal ownership and move semantics do not line up cleanly with that model, so the crate
+implements explicit infrastructure in `object.rs`.
+
+### `StaticKernelObject`
+
+`StaticKernelObject<T>` is the abstraction for statically declared Zephyr kernel objects. It tracks
+single initialization with an atomic state machine and is paired with the `Wrapped` trait so each
+raw Zephyr object can expose a more usable Rust wrapper.
+
+This is how types like:
+
+- `StaticMutex`
+- `StaticCondvar`
+- `StaticThread`
+- `StaticStoppedTimer`
+
+are made usable from Rust.
+
+### `kobj_define!`
+
+The `kobj_define!` macro is the user-facing declaration mechanism for static Zephyr kernel objects.
+It emits the linker decorations and storage layout expected by Zephyr, including special handling
+for thread stacks and object arrays.
+
+This is a core integration point with Zephyr's build and object registration model.
+
+### `ZephyrObject`
+
+For dynamically owned but fixed-address objects, `ZephyrObject<T>` provides delayed initialization
+plus runtime move detection. The object starts zeroed and uninitialized, is initialized on first
+use inside a critical section, and records the address at which initialization occurred. If it is
+moved afterward, the crate panics.
+
+This is the crate's way of reconciling Rust move semantics with Zephyr objects that become
+self-referential or address-sensitive after initialization.
+
+### `Fixed`
+
+`Fixed<T>` abstracts over:
+
+- static kernel-object-backed storage;
+- pinned owned storage when allocation is available.
+
+This allows APIs like timers and work queues to support both static and dynamically allocated usage
+without requiring separate code paths everywhere.
+
+## Time Model
+
+`time.rs` defines Zephyr-oriented time types using `fugit` rather than trying to mirror
+`std::time` exactly.
+
+Important choices:
+
+- `Duration` and `Instant` are parameterized in system ticks, not nanoseconds;
+- `Timeout` wraps Zephyr's `k_timeout_t`;
+- conversions preserve Zephyr's special timeout semantics such as `K_FOREVER`, `K_NO_WAIT`, and
+  absolute timeouts on 64-bit timeout builds;
+- the implementation is tied directly to `CONFIG_SYS_CLOCK_TICKS_PER_SEC`.
+
+This makes the time model efficient and Zephyr-native, but also intentionally configuration-aware.
+
+## Error Model
+
+`error.rs` is intentionally small. Zephyr APIs that return negative errno values are mapped to:
+
+- `Error(u32)`
+- `Result<T>`
+
+The crate does not currently try to model errnos as a rich enum. That keeps wrappers cheap and
+simple, but means error values remain mostly numeric.
+
+## `sys` Layer
+
+`zephyr::sys` is the "safe but still Zephyr-shaped" layer.
+
+It provides:
+
+- constants like `K_FOREVER` and `K_NO_WAIT`;
+- direct wrappers over kernel primitives;
+- a `critical-section` implementation based on `irq_lock()`/`irq_unlock()`;
+- thread and queue wrappers;
+- synchronization wrappers around `k_sem`, `k_mutex`, and `k_condvar`.
+
+This layer generally avoids imposing Rust ownership policy beyond what is needed to make the calls
+memory-safe.
+
+That separation matters:
+
+- `sys` is where direct Zephyr semantics are preserved;
+- `sync` and other higher-level modules are where Rust-specific structure is added.
+
+## Synchronization Design
+
+Synchronization is split into two layers.
+
+### Low-Level Primitives
+
+`sys::sync` exposes wrappers around Zephyr kernel objects. These are useful when the underlying
+Zephyr primitive is already a reasonable API on its own, especially `Semaphore`.
+
+### Higher-Level Rust Primitives
+
+`sync` builds Rust-style wrappers on top:
+
+- `sync::Mutex<T>` stores protected data alongside a Zephyr mutex and returns RAII guards;
+- `sync::Condvar` mirrors the `std`-style pairing with `MutexGuard`;
+- `sync::SpinMutex<T>` provides IRQ-safe protection using `k_spinlock`;
+- `sync::channel` implements close-to-`crossbeam-channel` semantics on top of `k_queue`;
+- `sync::atomic` re-exports `portable-atomic`;
+- `sync::Arc` and related types come from `portable-atomic-util`.
+
+Notable design consequences:
+
+- the crate supports targets without native atomics by leaning on `portable-atomic` plus the
+  `critical-section` implementation;
+- `SpinMutex` exists specifically because Zephyr mutexes are not IRQ-safe;
+- channels deliberately inherit Zephyr queue limitations, including incomplete drop/disconnect
+  semantics.
+
+## Threads
+
+Thread support also has two layers.
+
+### `sys::thread`
+
+This layer models the traditional Zephyr approach:
+
+- statically allocated `k_thread` plus stack;
+- explicit creation and startup;
+- optional closure-based spawn when allocation is available;
+- helper macros and types for stack declarations.
+
+### `thread`
+
+This higher-level module adds a reusable-thread model based on thread pools and shared startup data.
+It is designed to support the `#[zephyr::thread]` proc macro and provide a friendlier interface for
+declaring Rust threads with arguments, start control, joining, and reuse after termination.
+
+Overall, the design keeps Zephyr's thread model visible rather than trying to replace it with a
+green-thread abstraction.
+
+## Devices and Devicetree Integration
+
+The device model is tightly coupled to generated devicetree code.
+
+### Generated Entry Points
+
+`zephyr-build` generates devicetree modules that call constructors such as:
+
+- `crate::device::gpio::Gpio::new(...)`
+- `crate::device::gpio::GpioPin::new(...)`
+- `crate::device::flash::FlashController::new(...)`
+- `crate::device::flash::FlashPartition::new(...)`
+
+### `Unique`
+
+The `device::Unique` helper enforces one-time construction of wrapper instances for device-tree
+generated objects. This is a pragmatic safeguard around shared static Zephyr devices.
+
+### Current Scope
+
+The current hand-written device wrappers are focused on:
+
+- GPIO controllers and GPIO pins;
+- flash controllers and flash partitions.
+
+GPIO also contains optional async waiting support under the `async-drivers` feature.
+
+This design makes device support extensible through devicetree augmentation plus hand-written Rust
+wrapper types, rather than requiring every device to be exposed manually at the raw FFI layer.
+
+## Logging and Console Output
+
+The crate has two related but distinct output paths.
+
+### `printk`
+
+`printk!` and `printkln!` format Rust arguments and emit them through Zephyr's console path via
+`k_str_out`. The implementation uses a small stack buffer and flushes in chunks.
+
+### `logging`
+
+`logging` integrates the `log` crate with Zephyr in a configuration-sensitive way:
+
+- use `printk` when Zephyr logging is unavailable or minimal;
+- use Zephyr's logging subsystem when full logging is enabled and allocation is available;
+- otherwise install a no-op logger.
+
+This keeps Rust logging aligned with Zephyr's logging configuration rather than inventing a
+separate logging path.
+
+## Allocation Strategy
+
+Allocation is feature- and configuration-gated by `CONFIG_RUST_ALLOC`.
+
+When enabled:
+
+- `alloc_impl.rs` installs a global allocator backed by Zephyr `malloc`/`free`;
+- modules such as `timer`, `work`, `simpletls`, channel internals, and closure-based thread spawn
+  become available;
+- `portable-atomic-util` facilities such as `Arc` are usable in practice.
+
+The crate does not attempt to emulate full `std`; it provides `alloc` support only.
+
+## Timers
+
+`timer.rs` wraps `k_timer` into explicit state-typed Rust objects:
+
+- `StoppedTimer`
+- `SimpleTimer`
+- `CallbackTimer`
+
+The key design choice is that a running callback timer must be pinned because Zephyr stores callback
+state inside the underlying timer object and invokes callbacks asynchronously from IRQ context.
+
+The API reflects this by:
+
+- separating stopped and running states;
+- making callback mode explicitly pinned;
+- stopping timers in `Drop` where safe to do so.
+
+## Work Queues
+
+`work.rs` wraps Zephyr work queues and related signaling primitives.
+
+The current design is deliberately opinionated:
+
+- only basic work queue support is implemented, despite Zephyr having additional work variants;
+- work queues are started from a `WorkQueueBuilder`;
+- work queues must never be dropped, because Zephyr provides no safe stop mechanism for their
+  backing thread;
+- a lightweight TLS map is used to associate current threads with work queues;
+- `Signal` wraps `k_poll_signal` for event-style coordination.
+
+This is one of the clearest places where the crate chooses explicit lifecycle restrictions instead
+of pretending the underlying Zephyr primitive is easier to own than it really is.
+
+## Embassy Integration
+
+`embassy` is feature-gated and intentionally separate from the base runtime.
+
+Current features:
+
+- `executor-zephyr`: an Embassy executor that parks on a Zephyr semaphore;
+- `time-driver`: a Zephyr-backed Embassy time driver.
+
+The integration strategy is not to replace Zephyr scheduling, but to let async Rust executors run
+on top of Zephyr threads and timers where that model is beneficial.
+
+## Panic Handling
+
+The crate defines the panic handler in `lib.rs`.
+
+Current behavior:
+
+- optionally print panic information with `printkln!` when `CONFIG_PRINTK` is enabled;
+- transfer control to an external `rust_panic_wrap()` function provided elsewhere in the build.
+
+This keeps panic behavior explicitly integrated with the surrounding Zephyr/C runtime.
+
+## Important Constraints and Tradeoffs
+
+### Build-Specific Surface
+
+`kconfig` and `devicetree` are generated per build, so part of the crate's API is inherently
+configuration-specific.
+
+### Tight Zephyr Coupling
+
+The crate is intentionally specific to Zephyr's object model, scheduler, devicetree, and build
+artifacts. It is not aiming to be a portable embedded HAL.
+
+### Partial Userspace Story
+
+Some infrastructure explicitly does not support `CONFIG_USERSPACE` yet, including the
+`critical-section` implementation.
+
+### Lifecycle Gaps
+
+Some Zephyr primitives do not offer the hooks needed for fully Rust-idiomatic lifecycle semantics.
+Examples visible in the source:
+
+- channels cannot implement proper disconnect/drop behavior;
+- work queues cannot be safely dropped;
+- some flash wrapper sharing is noted as not fully safe yet.
+
+### No `std`
+
+The crate provides selected higher-level facilities, but does not try to reproduce the full Rust
+standard library API surface.
+
+### Safety Is Layered, Not Absolute
+
+The crate removes a large amount of `unsafe` from application code, but some APIs remain explicitly
+unsafe where Zephyr semantics cannot honestly be represented as fully safe Rust.
+
+## Extending the Crate
+
+Based on the current structure, extensions generally fall into one of these buckets:
+
+1. add or expand raw bindings in `zephyr-sys`;
+2. expose them thinly in `zephyr::sys`;
+3. build a higher-level Rust wrapper in `zephyr`;
+4. add devicetree augmentation plus typed device wrappers when the feature is device-oriented;
+5. gate optional subsystems behind Cargo features and/or Zephyr Kconfig when they depend on alloc
+   or extra ecosystem crates.
+
+The current design favors incremental growth in those layers rather than large monolithic APIs.
+
+## Non-Goals
+
+From the current source, `zephyr` is not trying to:
+
+- be a general-purpose OS abstraction layer;
+- hide Zephyr concepts behind unrelated Rust terminology;
+- provide full `std` compatibility;
+- make every Zephyr primitive look fully safe if its lifecycle semantics do not justify that;
+- provide board-independent documentation for generated build-specific modules.
+
+## Summary
+
+`zephyr` is the main Rust support crate for running on Zephyr. Its design centers on a layered
+approach:
+
+- generated build reflection from `zephyr-build`;
+- raw ABI access through `zephyr-sys`;
+- thin safe wrappers in `sys`;
+- higher-level Rust APIs for synchronization, devices, timers, work, logging, and threads;
+- explicit infrastructure for Zephyr kernel objects and fixed-address semantics.
+
+The result is a crate that tries to be idiomatic where possible, but remains honest about Zephyr's
+underlying model and constraints.


### PR DESCRIPTION
## Summary
- Add DESIGN.md files for zephyr, zephyr-build, zephyr-macros, and zephyr-sys crates
- Document the `zephyr_build::dt_cfgs()` call in the top-level README

## Test plan
- [ ] Review documentation for accuracy