### PR TITLE
zephyr-sys: selective binding exports based on kconfig

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ Then, you will need a ``build.rs`` file to call the support function.  The follo
 .. code-block:: rust
 
    fn main() {
-       zephyr_build::export_bool_kconfig();
+       zephyr_build::export_kconfig_bool_options();
    }
 
 At this point, it will be possible to use the ``cfg`` directive in Rust on boolean Kconfig values.

--- a/dt-rust.yaml
+++ b/dt-rust.yaml
@@ -6,6 +6,7 @@
 # Gpio controllers match for every node that has a `gpio-controller` property.  This is one of the
 # few instances were we can actually just match on a property.
 - name: gpio-controller
+  cfg: CONFIG_GPIO
   rules:
     - !HasProp gpio-controller
   actions:
@@ -18,6 +19,7 @@
 # having this compatible property.  The nodes themselves are built out of the properties associated
 # with each gpio.
 - name: gpio-leds
+  cfg: CONFIG_GPIO
   rules:
     - !Compatible
       names: [gpio-leds]
@@ -30,6 +32,7 @@
 # Flash controllers don't have any particular property to identify them, so we need a list of
 # compatible values that should match.
 - name: flash-controller
+  cfg: CONFIG_FLASH
   rules:
     - !Compatible
       names:
@@ -50,6 +53,7 @@
 # of the controller itself.
 # TODO: Get the write and erase property from the DT if present.
 - name: flash-partition
+  cfg: CONFIG_FLASH
   rules:
     - !Compatible
       names:

--- a/samples/async-philosophers/build.rs
+++ b/samples/async-philosophers/build.rs
@@ -5,5 +5,5 @@
 // zephyr-build must be a build dependency.
 
 fn main() {
-    zephyr_build::export_bool_kconfig();
+    zephyr_build::export_kconfig_bool_options();
 }

--- a/samples/bench/build.rs
+++ b/samples/bench/build.rs
@@ -5,5 +5,5 @@
 // zephyr-build must be a build dependency.
 
 fn main() {
-    zephyr_build::export_bool_kconfig();
+    zephyr_build::export_kconfig_bool_options();
 }

--- a/samples/philosophers/build.rs
+++ b/samples/philosophers/build.rs
@@ -5,5 +5,5 @@
 // zephyr-build must be a build dependency.
 
 fn main() {
-    zephyr_build::export_bool_kconfig();
+    zephyr_build::export_kconfig_bool_options();
 }

--- a/zephyr-build/src/devicetree/augment.rs
+++ b/zephyr-build/src/devicetree/augment.rs
@@ -56,6 +56,9 @@ pub struct Augmentation {
     rules: Vec<Rule>,
     /// What to do when a given node matches.
     actions: Vec<Action>,
+    /// Optional kconfig option to gate the generated code with `#[cfg(...)]`.
+    #[serde(default)]
+    cfg: Option<String>,
 }
 
 impl Augment for Augmentation {
@@ -65,7 +68,14 @@ impl Augment for Augmentation {
 
     fn generate(&self, node: &Node, tree: &DeviceTree) -> TokenStream {
         let name = format_ident!("{}", dt_to_lower_id(&self.name));
-        let actions = self.actions.iter().map(|a| a.generate(&name, node, tree));
+        let cfg_attr = self.cfg.as_ref().map(|cfg_name| {
+            let cfg_id = format_ident!("{}", cfg_name);
+            quote! { #[cfg(#cfg_id)] }
+        });
+        let actions = self
+            .actions
+            .iter()
+            .map(|a| a.generate(&name, node, tree, &cfg_attr));
 
         quote! {
             #(#actions)*
@@ -136,13 +146,19 @@ pub enum Action {
 }
 
 impl Action {
-    fn generate(&self, _name: &Ident, node: &Node, tree: &DeviceTree) -> TokenStream {
+    fn generate(
+        &self,
+        _name: &Ident,
+        node: &Node,
+        tree: &DeviceTree,
+        cfg_attr: &Option<TokenStream>,
+    ) -> TokenStream {
         match self {
             Action::Instance {
                 raw,
                 device,
                 static_type,
-            } => raw.generate(node, device, static_type.as_deref()),
+            } => raw.generate(node, device, static_type.as_deref(), cfg_attr),
             Action::Labels => {
                 let nodes = tree.labels.iter().map(|(k, v)| {
                     let name = dt_to_lower_id(k);
@@ -184,7 +200,13 @@ pub enum RawInfo {
 }
 
 impl RawInfo {
-    fn generate(&self, node: &Node, device: &str, static_type: Option<&str>) -> TokenStream {
+    fn generate(
+        &self,
+        node: &Node,
+        device: &str,
+        static_type: Option<&str>,
+        cfg_attr: &Option<TokenStream>,
+    ) -> TokenStream {
         let device_id = str_to_path(device);
         let static_type = str_to_path(static_type.unwrap_or("crate::device::NoStatic"));
         match self {
@@ -194,17 +216,22 @@ impl RawInfo {
                 match node.get_single_string("status") {
                     Some("okay") | Some("ok") | None => {
                         quote! {
+                            #cfg_attr
                             /// Get the raw `const struct device *` of the device tree generated node.
                             pub unsafe fn get_instance_raw() -> *const crate::raw::device {
                                 &crate::raw::#rawdev
                             }
+                            #cfg_attr
                             #[allow(dead_code)]
                             pub(crate) unsafe fn get_static_raw() -> &'static #static_type {
                                 &STATIC
                             }
 
+                            #cfg_attr
                             static UNIQUE: crate::device::Unique = crate::device::Unique::new();
+                            #cfg_attr
                             static STATIC: #static_type = #static_type::new();
+                            #cfg_attr
                             pub fn get_instance() -> Option<#device_id> {
                                 unsafe {
                                     let device = get_instance_raw();
@@ -235,8 +262,11 @@ impl RawInfo {
                 let target_route = target.route_to_rust();
 
                 quote! {
+                    #cfg_attr
                     static UNIQUE: crate::device::Unique = crate::device::Unique::new();
+                    #cfg_attr
                     static STATIC: #static_type = #static_type::new();
+                    #cfg_attr
                     pub fn get_instance() -> Option<#device_id> {
                         unsafe {
                             let device = #target_route :: get_instance_raw();
@@ -256,8 +286,11 @@ impl RawInfo {
                 }
 
                 quote! {
+                    #cfg_attr
                     static UNIQUE: crate::device::Unique = crate::device::Unique::new();
+                    #cfg_attr
                     static STATIC: #static_type = #static_type::new();
+                    #cfg_attr
                     pub fn get_instance() -> Option<#device_id> {
                         unsafe {
                             let device = #path :: get_instance_raw();

--- a/zephyr-build/src/lib.rs
+++ b/zephyr-build/src/lib.rs
@@ -31,17 +31,12 @@ pub fn extract_kconfig_bool_options(path: &str) -> anyhow::Result<HashSet<String
     let config_y = Regex::new(r"^(CONFIG_.*)=y$").expect("hardcoded regex is always valid");
 
     let input = File::open(path)?;
-    let flags: HashSet<String> =
-        BufReader::new(input)
-            .lines()
-            .fold(HashSet::new(), |mut set, line| {
-                if let Ok(line) = &line {
-                    if let Some(caps) = config_y.captures(line) {
-                        set.insert(caps[1].into());
-                    }
-                }
-                set
-            });
+    let flags: HashSet<String> = BufReader::new(input)
+        .lines()
+        // If the line is an Err(_), just ignore it.
+        .map(|x| x.unwrap_or_default())
+        .filter_map(|line| config_y.captures(&line).map(|caps| caps[1].to_string()))
+        .collect();
 
     Ok(flags)
 }

--- a/zephyr-build/src/lib.rs
+++ b/zephyr-build/src/lib.rs
@@ -11,6 +11,7 @@
 // This builds a program that is run on the compilation host before the code is compiled.  It can
 // output configuration settings that affect the compilation.
 
+use std::collections::HashSet;
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
@@ -24,24 +25,40 @@ use devicetree::{Augment, DeviceTree};
 
 mod devicetree;
 
+/// Extract boolean Kconfig entries.  This must happen in any crate that wishes to access the
+/// configuration settings.
+pub fn extract_kconfig_bool_options(path: &str) -> anyhow::Result<HashSet<String>> {
+    let config_y = Regex::new(r"^(CONFIG_.*)=y$").expect("hardcoded regex is always valid");
+
+    let input = File::open(path)?;
+    let flags: HashSet<String> =
+        BufReader::new(input)
+            .lines()
+            .fold(HashSet::new(), |mut set, line| {
+                if let Ok(line) = &line {
+                    if let Some(caps) = config_y.captures(line) {
+                        set.insert(caps[1].into());
+                    }
+                }
+                set
+            });
+
+    Ok(flags)
+}
+
 /// Export boolean Kconfig entries.  This must happen in any crate that wishes to access the
 /// configuration settings.
-pub fn export_bool_kconfig() {
+pub fn export_kconfig_bool_options() {
     let dotconfig = env::var("DOTCONFIG").expect("DOTCONFIG must be set by wrapper");
 
     // Ensure the build script is rerun when the dotconfig changes.
     println!("cargo:rerun-if-env-changed=DOTCONFIG");
     println!("cargo-rerun-if-changed={}", dotconfig);
 
-    let config_y = Regex::new(r"^(CONFIG_.*)=y$").unwrap();
-
-    let file = File::open(&dotconfig).expect("Unable to open dotconfig");
-    for line in BufReader::new(file).lines() {
-        let line = line.expect("reading line from dotconfig");
-        if let Some(caps) = config_y.captures(&line) {
-            println!("cargo:rustc-cfg={}", &caps[1]);
-        }
-    }
+    extract_kconfig_bool_options(&dotconfig)
+        .expect("failed to extract flags from .config")
+        .iter()
+        .for_each(|flag| println!("cargo:rustc-cfg={flag}"));
 }
 
 /// Capture bool, numeric and string kconfig values in a 'kconfig' module.

--- a/zephyr-sys/Cargo.toml
+++ b/zephyr-sys/Cargo.toml
@@ -15,4 +15,4 @@ Zephyr low-level API bindings.
 [build-dependencies]
 anyhow = "1.0"
 bindgen = { version = "0.72.1", features = ["experimental"] }
-# zephyr-build = { version = "0.1.0", path = "../zephyr-build" }
+zephyr-build = { version = "0.1.0", path = "../zephyr-build" }

--- a/zephyr-sys/build.rs
+++ b/zephyr-sys/build.rs
@@ -11,14 +11,12 @@
 // This builds a program that is run on the compilation host before the code is compiled.  It can
 // output configuration settings that affect the compilation.
 
-use anyhow::Result;
-
-use bindgen::Builder;
-
 use std::env;
 use std::path::{Path, PathBuf};
 
-fn main() -> Result<()> {
+use bindgen::Builder;
+
+fn main() -> anyhow::Result<()> {
     // Determine which version of Clang we linked with.
     let version = bindgen::clang_version();
     println!("Clang version: {:?}", version);
@@ -55,6 +53,9 @@ fn main() -> Result<()> {
 
     // Bindgen everything.
     let bindings = Builder::default()
+        .clang_arg("-DRUST_BINDGEN")
+        .clang_arg(format!("-I{}/lib/libc/minimal/include", zephyr_base))
+        .clang_arg(&target_arg)
         .header(
             Path::new("wrapper.h")
                 .canonicalize()
@@ -62,43 +63,56 @@ fn main() -> Result<()> {
                 .to_str()
                 .unwrap(),
         )
-        .use_core()
-        .clang_arg(&target_arg);
+        .use_core();
+
     let bindings = define_args(bindings, "-I", "INCLUDE_DIRS");
     let bindings = define_args(bindings, "-D", "INCLUDE_DEFINES");
+
     let bindings = bindings
         .wrap_static_fns(true)
-        .wrap_static_fns_path(wrapper_path)
-        // <inttypes.h> seems to come from somewhere mysterious in Zephyr.  For us, just pull in the
-        // one from the minimal libc.
-        .clang_arg("-DRUST_BINDGEN")
-        .clang_arg(format!("-I{}/lib/libc/minimal/include", zephyr_base))
-        .derive_copy(false)
-        .derive_default(true)
-        .allowlist_function("k_.*")
-        .allowlist_function("gpio_.*")
-        .allowlist_function("flash_.*")
-        .allowlist_function("zr_.*")
-        .allowlist_item("GPIO_.*")
-        .allowlist_item("FLASH_.*")
-        .allowlist_item("Z_.*")
-        .allowlist_item("ZR_.*")
-        .allowlist_item("K_.*")
-        // Each DT node has a device entry that is a static.
-        .allowlist_item("__device_dts_ord.*")
-        .allowlist_function("device_.*")
-        .allowlist_function("sys_.*")
-        .allowlist_function("z_log.*")
-        .allowlist_function("bt_.*")
-        .allowlist_function("SEGGER.*")
+        .wrap_static_fns_path(wrapper_path);
+
+    let bindings = bindings.derive_copy(false).derive_default(true);
+
+    let bindings = bindings
+        // Deprecated
+        .blocklist_function("sys_clock_timeout_end_calc")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
+
+    let dotconfig = env::var("DOTCONFIG").expect("missing DOTCONFIG path");
+    let options = zephyr_build::extract_kconfig_bool_options(&dotconfig)
+        .expect("failed to extract kconfig boolean options");
+
+    let bindings = bindings
+        // Kernel
         .allowlist_item("E.*")
         .allowlist_item("K_.*")
+        .allowlist_item("Z_.*")
         .allowlist_item("ZR_.*")
         .allowlist_item("LOG_LEVEL_.*")
         .allowlist_item("k_poll_modes")
-        // Deprecated
-        .blocklist_function("sys_clock_timeout_end_calc")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        // Each DT node has a device entry that is a static.
+        .allowlist_item("__device_dts_ord.*")
+        .allowlist_function("k_.*")
+        .allowlist_function("z_log.*")
+        .allowlist_function("sys_.*")
+        .allowlist_function("zr_.*")
+        .allowlist_function("device_.*")
+        .allowlist_function("SEGGER.*")
+        // Bluetooth
+        .allowlist_item_if("CONFIG_BT_.*", || options.contains("CONFIG_BT"))
+        .allowlist_function_if("bt_.*", || options.contains("CONFIG_BT"))
+        // GPIO
+        .allowlist_item_if("CONFIG_GPIO_.*", || options.contains("CONFIG_GPIO"))
+        .allowlist_item_if("GPIO_.*", || options.contains("CONFIG_GPIO"))
+        .allowlist_function_if("gpio_.*", || options.contains("CONFIG_GPIO"))
+        // Flash
+        .allowlist_item_if("FLASH_.*", || options.contains("CONFIG_FLASH"))
+        .allowlist_function_if("flash_.*", || options.contains("CONFIG_FLASH"))
+        // UART
+        .allowlist_item_if("CONFIG_UART_.*", || options.contains("CONFIG_SERIAL"))
+        .allowlist_function_if("uart_.*", || options.contains("CONFIG_SERIAL"))
+        // Generate
         .generate()
         .expect("Unable to generate bindings");
 
@@ -107,6 +121,42 @@ fn main() -> Result<()> {
         .expect("Couldn't write bindings!");
 
     Ok(())
+}
+
+trait BuilderExt {
+    type B;
+
+    fn allowlist_function_if<P>(self, pattern: &str, pred: P) -> Self::B
+    where
+        P: FnOnce() -> bool;
+
+    fn allowlist_item_if<P>(self, pattern: &str, pred: P) -> Self::B
+    where
+        P: FnOnce() -> bool;
+}
+
+impl BuilderExt for Builder {
+    type B = Builder;
+
+    fn allowlist_function_if<P>(self, pattern: &str, pred: P) -> Self::B
+    where
+        P: FnOnce() -> bool,
+    {
+        if pred() {
+            return self.allowlist_function(pattern);
+        }
+        self
+    }
+
+    fn allowlist_item_if<P>(self, pattern: &str, pred: P) -> Self::B
+    where
+        P: FnOnce() -> bool,
+    {
+        if pred() {
+            return self.allowlist_item(pattern);
+        }
+        self
+    }
 }
 
 fn define_args(bindings: Builder, prefix: &str, var_name: &str) -> Builder {

--- a/zephyr-sys/build.rs
+++ b/zephyr-sys/build.rs
@@ -87,6 +87,7 @@ fn main() -> anyhow::Result<()> {
         // Kernel
         .allowlist_item("E.*")
         .allowlist_item("K_.*")
+        .allowlist_item("LOG_.*")
         .allowlist_item("Z_.*")
         .allowlist_item("ZR_.*")
         .allowlist_item("LOG_LEVEL_.*")

--- a/zephyr-sys/build.rs
+++ b/zephyr-sys/build.rs
@@ -50,8 +50,8 @@ fn main() -> Result<()> {
     // println!("includes: {:?}", env::var("INCLUDE_DIRS"));
     // println!("defines: {:?}", env::var("INCLUDE_DEFINES"));
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let wrapper_path = PathBuf::from(env::var("WRAPPER_FILE").unwrap());
+    let out_path = PathBuf::from(env::var("OUT_DIR").expect("missing output directory"));
+    let wrapper_path = PathBuf::from(env::var("WRAPPER_FILE").expect("missing wrapper file"));
 
     // Bindgen everything.
     let bindings = Builder::default()
@@ -110,7 +110,7 @@ fn main() -> Result<()> {
 }
 
 fn define_args(bindings: Builder, prefix: &str, var_name: &str) -> Builder {
-    let text = env::var(var_name).unwrap();
+    let text = env::var(var_name).expect("missing environment variable");
     let mut bindings = bindings;
     // Split on either spaces or semicolons, to allow some flexibility in what cmake might generate
     // for us.

--- a/zephyr-sys/wrapper.h
+++ b/zephyr-sys/wrapper.h
@@ -38,10 +38,13 @@ extern int errno;
 
 #include <zephyr/kernel.h>
 #include <zephyr/kernel/thread_stack.h>
+
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/logging/log.h>
+#include <zephyr/drivers/uart.h>
+
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
 
 /*

--- a/zephyr/build.rs
+++ b/zephyr/build.rs
@@ -12,7 +12,7 @@
 // output configuration settings that affect the compilation.
 
 fn main() {
-    zephyr_build::export_bool_kconfig();
+    zephyr_build::export_kconfig_bool_options();
     zephyr_build::build_kconfig_mod();
     zephyr_build::build_dts();
 }

--- a/zephyr/src/device.rs
+++ b/zephyr/src/device.rs
@@ -10,7 +10,9 @@
 
 use crate::sync::atomic::{AtomicBool, Ordering};
 
+#[cfg(CONFIG_FLASH)]
 pub mod flash;
+#[cfg(CONFIG_GPIO)]
 pub mod gpio;
 
 // Allow dead code, because it isn't required for a given build to have any devices.


### PR DESCRIPTION
## Summary

This PR is based on the work by @inthehack in #39, rebased onto current
main and extended with additional changes. Thank you to @inthehack for
the original contribution.

The original PR introduced selective generation of bindgen allowlists
based on kconfig options, so that missing subsystem support surfaces as
Rust compile errors rather than linker failures. The core idea is:

- Extract kconfig boolean options into a reusable `HashSet` in
  `zephyr-build`, separate from the cargo cfg export.
- Use `allowlist_function_if` / `allowlist_item_if` extension traits in
  `zephyr-sys/build.rs` to conditionally include bindings for BT, GPIO,
  Flash, and UART based on the active kconfig.

Changes made during the rebase and integration:

- Resolved conflicts with current main (devicetree module, updated
  bindgen builder chain, new allowlist entries for flash/device/SEGGER).
- Fixed a bug in the iterator refactoring where `filter` + `collect`
  captured the entire `.config` line (e.g. `CONFIG_FOO=y`) instead of
  just the key (`CONFIG_FOO`), causing invalid `--cfg` arguments.
- Fixed the function rename (`export_bool_kconfig` →
  `export_kconfig_bool_options`) in all samples and README.
- Added `#[cfg(CONFIG_GPIO)]` and `#[cfg(CONFIG_FLASH)]` gates on the
  device modules in the `zephyr` crate so that higher-level Rust
  wrappers are only compiled when the subsystem is enabled.
- Added an optional `cfg` field to the devicetree augmentation config
  (`dt-rust.yaml`) so that generated DT bindings for GPIO and flash
  nodes are also gated behind their respective kconfig options.

## Test plan

- [x] Full twister CI pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)