### PR TITLE
Suppress dead_code and unnecessary_transmutes compiler warnings

### DIFF
--- a/zephyr-sys/src/lib.rs
+++ b/zephyr-sys/src/lib.rs
@@ -20,6 +20,7 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::transmute_int_to_bool)]
 #![allow(clippy::useless_transmute)]
+#![allow(unnecessary_transmutes)]
 #![allow(clippy::len_without_is_empty)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 

--- a/zephyr/src/logging.rs
+++ b/zephyr/src/logging.rs
@@ -62,12 +62,14 @@ cfg_if::cfg_if! {
 // TODO: Allow the default level to be set through Kconfig.
 cfg_if::cfg_if! {
     if #[cfg(target_has_atomic = "ptr")] {
+        #[allow(dead_code)]
         unsafe fn set_logger_internal(logger: &'static dyn Log) -> Result<(), SetLoggerError> {
             log::set_logger(logger)?;
             log::set_max_level(LevelFilter::Info);
             Ok(())
         }
     } else {
+        #[allow(dead_code)]
         unsafe fn set_logger_internal(logger: &'static dyn Log) -> Result<(), SetLoggerError> {
             log::set_logger_racy(logger)?;
             log::set_max_level_racy(LevelFilter::Info);


### PR DESCRIPTION
## Summary

Two compiler warnings that appear with Rust 1.94+ on embedded targets:

1. **logging.rs dead_code** — set_logger_internal() is defined in both branches of a cfg_if (target_has_atomic="ptr" vs not) but only the active branch is called. The inactive branch triggers a dead_code warning. Add #[allow(dead_code)] to both.

2. **zephyr-sys unnecessary_transmutes** — bindgen emits transmute(x: u8) -> u8 for some bitfield accessors. Rust 1.94 added the unnecessary_transmutes lint which fires on these no-op transmutes. Add #![allow(unnecessary_transmutes)] as a crate-level inner attribute in lib.rs (inner attributes in include!()-ed files are rejected).

## Test plan

- [x] Build with Rust 1.94.0 targeting thumbv8m.main-none-eabihf
- [x] Verify no warnings from logging.rs or zephyr-sys bindings