### PR TITLE
dt-rust: add STM32 flash controller bindings

### DIFF
--- a/dt-rust.yaml
+++ b/dt-rust.yaml
@@ -33,6 +33,21 @@
   rules:
     - !Compatible
       names:
+        - "st,stm32-flash-controller"
+        - "st,stm32c5-flash-controller"
+        - "st,stm32f1-flash-controller"
+        - "st,stm32f2-flash-controller"
+        - "st,stm32f4-flash-controller"
+        - "st,stm32f7-flash-controller"
+        - "st,stm32g0-flash-controller"
+        - "st,stm32g4-flash-controller"
+        - "st,stm32h7-flash-controller"
+        - "st,stm32l4-flash-controller"
+        - "st,stm32l5-flash-controller"
+        - "st,stm32u3-flash-controller"
+        - "st,stm32wb0-flash-controller"
+        - "st,stm32wba-flash-controller"
+        - "st,stm32wb-flash-controller"
         - "nordic,nrf52-flash-controller"
         - "nordic,nrf51-flash-controller"
         - "raspberrypi,pico-flash-controller"

--- a/dt-rust.yaml
+++ b/dt-rust.yaml
@@ -56,6 +56,9 @@
         - "raspberrypi,pico-flash-controller"
         - "zephyr,sim-flash"
         - "st,stm32-flash-controller"
+        - "st,stm32-qspi-nor"
+        - "st,stm32-ospi-nor"
+        - "st,stm32-xspi-nor"
         - "nxp,msf1"
         - "espressif,esp32-flash-controller"
       level: 0

--- a/etc/platforms.txt
+++ b/etc/platforms.txt
@@ -6,3 +6,4 @@
 -p frdm_mcxa156/mcxa156
 -p esp32c3_supermini/esp32c3
 -p nrf5340dk/nrf5340/cpuapp
+-p stm32h573i_dk


### PR DESCRIPTION
## Summary

After rebasing onto current main, this PR was mostly obsoleted by #109,
which added the generic `st,stm32-flash-controller` to dt-rust.yaml's
flash-controller list. Every STM32 SoC's flash-controller node lists
that string in its `compatible` array, so the augment matcher fires for
all internal STM32 flash controllers without family-specific entries.
The original 15 family-specific compatibles in this branch were dropped
in the rebase.

What this PR does add are three external NOR flash-controller
compatibles that are still missing on main:

- `st,stm32-qspi-nor` (QuadSPI — F7/L4/H7-era)
- `st,stm32-ospi-nor` (OctoSPI — H7/L4/L5/U5)
- `st,stm32-xspi-nor` (XSPI — H5/U5/N6)

Without these, boards with external SPI NOR flash (e.g.,
`stm32h573i_dk`'s MX25LM51245G on XSPI) fail to build the `zephyr`
crate: the flash-partition augment generates
`super::super::super::get_instance_raw()` for fixed-partition children
of `soc-nv-flash`, expecting the grandparent controller node to be a
registered flash-controller. With the controller's compatible absent
from dt-rust.yaml's names list, that resolution fails.

`stm32h573i_dk` is added to `etc/platforms.txt` to give CI an STM32 +
Cortex-M33 + XSPI-NOR target (none of those are exercised today) and to
catch regressions in the new path.

## Test plan

- [x] `west build -b stm32h573i_dk samples/blinky` — builds clean (was
      failing on main due to the missing XSPI compatible)
- [x] Generated `devicetree.rs` registers `xspi_flash_controller_0`
      with `get_instance_raw()` emitted at the controller node
- [x] Flashed to a real STM32H573I-DK over STLINK-V3
- [x] LD4 (blue, `aliases::led0`) blinks at the expected rate;
      confirmed change in rate after edit + reflash to rule out a
      stale image