### PR TITLE
Add license = "Apache-2.0" to zephyr, zephyr-build, and zephyr-sys Cargo.toml

### DIFF
--- a/zephyr-build/Cargo.toml
+++ b/zephyr-build/Cargo.toml
@@ -5,6 +5,7 @@
 name = "zephyr-build"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 description = """
 Build-time support for Rust-based applications that run on Zephyr.
 Provides utilities for accessing Kconfig and devicetree information.

--- a/zephyr-sys/Cargo.toml
+++ b/zephyr-sys/Cargo.toml
@@ -5,6 +5,7 @@
 name = "zephyr-sys"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 description = """
 Zephyr low-level API bindings.
 """

--- a/zephyr/Cargo.toml
+++ b/zephyr/Cargo.toml
@@ -5,6 +5,7 @@
 name = "zephyr"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 description = """
 Functionality for Rust-based applications that run on Zephyr.
 """


### PR DESCRIPTION
This patch adds license = "Apache-2.0" to the [package] section of:

  - `zephyr/Cargo.toml`
  - `zephyr-build/Cargo.toml`
  - `zephyr-sys/Cargo.toml`

These crates already carry a `# SPDX-License-Identifier: Apache-2.0` comment at the top of their Cargo.toml, so the licensing intent is unambiguous. But Cargo, crates.io, and downstream license-audit tools (e.g. cargo-deny, cargo-about) read the `[package].license field`, not file-header comments.

This PR fixes that, so license checks don't have to work around the missing field.
No change to the license terms, only declaring the existing terms in the location Cargo expects.