### PR TITLE
Migrate paste to pastey (RUSTSEC-2024-0436)

### DIFF
--- a/zephyr-build/Cargo.toml
+++ b/zephyr-build/Cargo.toml
@@ -5,6 +5,7 @@
 name = "zephyr-build"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 description = """
 Build-time support for Rust-based applications that run on Zephyr.
 Provides utilities for accessing Kconfig and devicetree information.

--- a/zephyr-sys/Cargo.toml
+++ b/zephyr-sys/Cargo.toml
@@ -5,6 +5,7 @@
 name = "zephyr-sys"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 description = """
 Zephyr low-level API bindings.
 """

--- a/zephyr/Cargo.toml
+++ b/zephyr/Cargo.toml
@@ -5,6 +5,7 @@
 name = "zephyr"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 description = """
 Functionality for Rust-based applications that run on Zephyr.
 """

--- a/zephyr/Cargo.toml
+++ b/zephyr/Cargo.toml
@@ -17,8 +17,10 @@ rust-version = "1.85"
 zephyr-sys = { version = "0.1.0", path = "../zephyr-sys" }
 zephyr-macros = { version = "0.1.0", path = "../zephyr-macros" }
 
-# Although paste is brought in, it is a compile-time macro, and is not linked into the application.
-paste = "1.0"
+# `pastey` is the maintained successor to `paste` (which was archived
+# upstream — see RUSTSEC-2024-0436). It is a drop-in API replacement,
+# and is a compile-time macro, so it is not linked into the application.
+pastey = "0.2"
 
 # cfg-if is a compile-time macro as well, to make conditional compilation a bit easier to write.
 cfg-if = "1.0"

--- a/zephyr/src/lib.rs
+++ b/zephyr/src/lib.rs
@@ -89,8 +89,10 @@ pub use error::{Error, Result};
 
 pub use logging::set_logger;
 
-/// Re-exported for local macro use.
-pub use paste::paste;
+/// Re-exported for local macro use. `pastey` is the maintained
+/// successor to `paste` (RUSTSEC-2024-0436); it is API-compatible, so
+/// the `$crate::paste!` callsites in `object.rs` etc. are unchanged.
+pub use pastey::paste;
 
 /// Re-export the proc macros.
 pub use zephyr_macros::thread;


### PR DESCRIPTION
The paste crate has been archived by its maintainer (see the announcement on GitHub) and now carries RUSTSEC-2024-0436 "no longer maintained." Downstream consumers running cargo-deny / cargo-audit either fail their advisory checks or have to add an ignore entry per project.                                   
                                                                  
pastey is the maintained fork and is documented as a drop-in replacement: same `paste!` macro, same grammar, same behavior. Upstream usage in zephyr-lang-rust is limited to one re-export (`pub use paste::paste` in `zephyr/src/lib.rs`) and two callsites inside macro definitions in `zephyr/src/object.rs` (`_kobj_stack` macro arms). Because the callsites use `$crate::paste! { ... }`, only the re-export needs to change. 
