### PR TITLE
Add Clippy to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Install Rust Targets
         shell: bash
         run: |
+          rustup component add clippy
           rustup target add riscv32i-unknown-none-elf
           rustup target add riscv64imac-unknown-none-elf
           rustup target add thumbv6m-none-eabi
@@ -81,6 +82,19 @@ jobs:
             cargo fmt --check
             cd - > /dev/null
           done
+
+      - name: Check clippy
+        working-directory: apptest
+        shell: bash
+        run: |
+          ../zephyr/scripts/twister -M all -T samples -T tests -E twister-testplan.json
+          while IFS=$'\t' read -r sample_path platform; do
+              build_dir="build_clippy/$platform/$sample_path"
+              printf 'Running clippy for %s on %s\n' "$sample_path" "$platform"
+              west build -b "$platform" -s "$sample_path" -d "$build_dir" -t clippy ${WEST_BUILD_EXTRA_ARGS:-}
+          done < <(
+              jq -r '.testsuites | unique_by(.path, .platform)[] | [.path, .platform] | @tsv' twister-testplan.json
+          )
 
       - name: Build firmware
         working-directory: apptest

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Cargo.lock
 
 # Cargo encourages a .cargo/config.toml file to symlink to a generated file.  Don't save these.
 .cargo/
+
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,16 @@ ${config_paths}
     COMMENT "Building Rust application"
   )
 
+  # Command to lint the Rust application.
+  add_cargo_target_with_zephyr_env(clippy
+    ALL
+    OUTPUT run_rust_clippy
+    CARGO_ARGS
+      clippy
+      --
+      -D warnings
+      -D clippy::undocumented_unsafe_blocks
+    COMMENT "Linting Rust application"
   )
 
   # Command to generate the rust docs.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,66 @@ function(get_include_dirs target dirs)
   endif()
 endfunction()
 
+function(add_cargo_target_with_zephyr_env target)
+  set(one_value_args OUTPUT COMMENT)
+  set(multi_value_args BYPRODUCTS CARGO_ARGS)
+  cmake_parse_arguments(CARGO_TARGET "ALL" "${one_value_args}" "${multi_value_args}" ${ARGN})
+
+  if(NOT CARGO_TARGET_OUTPUT)
+    message(FATAL_ERROR "add_cargo_target_with_zephyr_env requires OUTPUT")
+  endif()
+
+  if(NOT CARGO_TARGET_CARGO_ARGS)
+    message(FATAL_ERROR "add_cargo_target_with_zephyr_env requires CARGO_ARGS")
+  endif()
+
+  if(CARGO_TARGET_ALL)
+    set(custom_target_all ALL)
+  else()
+    set(custom_target_all)
+  endif()
+
+  set(cargo_args ${CARGO_TARGET_CARGO_ARGS})
+  list(POP_FRONT cargo_args cargo_command)
+
+  add_custom_command(
+    OUTPUT ${CARGO_TARGET_OUTPUT}
+    BYPRODUCTS ${CARGO_TARGET_BYPRODUCTS}
+    USES_TERMINAL
+    COMMAND
+      ${CMAKE_COMMAND} -E
+      env BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
+      ZEPHYR_BASE=${ZEPHYR_BASE}
+      DOTCONFIG=${DOTCONFIG}
+      ZEPHYR_DTS=${ZEPHYR_DTS}
+      INCLUDE_DIRS="${include_dirs}"
+      INCLUDE_DEFINES="${include_defines}"
+      WRAPPER_FILE="${WRAPPER_FILE}"
+      DT_AUGMENTS="${DT_AUGMENTS}"
+      BINARY_DIR_INCLUDE_GENERATED="${BINARY_DIR_INCLUDE_GENERATED}"
+      cargo ${cargo_command}
+      ${rust_build_type_arg}
+
+      # Set a replacement so that packages can just use `zephyr-sys` as a package
+      # name to find it.
+      ${command_paths}
+      --target ${RUST_TARGET}
+      --target-dir ${CARGO_TARGET_DIR}
+      ${cargo_args}
+    COMMENT "${CARGO_TARGET_COMMENT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+  add_custom_target(${target} ${custom_target_all}
+    DEPENDS ${CARGO_TARGET_OUTPUT}
+        # The variables, defined at the top level, don't seem to be accessible here.
+        offsets_h
+        syscall_list_h_target
+        driver_validation_h_target
+        kobj_types_h_target
+  )
+endfunction()
+
 function(rust_cargo_application)
   # For now, hard-code the Zephyr crate directly here.  Once we have
   # more than one crate, these should be added by the modules
@@ -152,96 +212,22 @@ DT_AUGMENTS = \"${DT_AUGMENTS}\"
 ${config_paths}
 ")
 
-  # The block of environment variables below could theoretically be captured in a variable, but this
-  # seems "challenging" in CMake (to be polite), as many of these contain spaces, and the quoting
-  # rules in CMake are inconsistent, at best.
-  # TODO: Figure out how to factor these out.
-
   # The library is built by invoking Cargo.
-  add_custom_command(
+  add_cargo_target_with_zephyr_env(librustapp
+    ALL
     OUTPUT ${DUMMY_FILE}
     BYPRODUCTS ${RUST_LIBRARY} ${WRAPPER_FILE}
-    USES_TERMINAL
-    COMMAND
-      ${CMAKE_COMMAND} -E
-      env BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
-      ZEPHYR_BASE=${ZEPHYR_BASE}
-      DOTCONFIG=${DOTCONFIG}
-      ZEPHYR_DTS=${ZEPHYR_DTS}
-      INCLUDE_DIRS="${include_dirs}"
-      INCLUDE_DEFINES="${include_defines}"
-      WRAPPER_FILE="${WRAPPER_FILE}"
-      DT_AUGMENTS="${DT_AUGMENTS}"
-      BINARY_DIR_INCLUDE_GENERATED="${BINARY_DIR_INCLUDE_GENERATED}"
-      cargo build
-      ${rust_build_type_arg}
-
-      # Override the features according to the shield given. For a general case,
-      # this will need to come from a variable or argument.
-      # TODO: This needs to be passed in.
-      # --no-default-features
-      # --features ${SHIELD_FEATURE}
-
-      # Set a replacement so that packages can just use `zephyr-sys` as a package
-      # name to find it.
-      ${command_paths}
-      --target ${RUST_TARGET}
-      --target-dir ${CARGO_TARGET_DIR}
+    CARGO_ARGS build
     COMMENT "Building Rust application"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-  # Be sure we don't try building this until all of the generated headers have been generated.
-  add_custom_target(librustapp ALL
-    DEPENDS ${DUMMY_FILE}
-        # The variables, defined at the top level, don't seem to be accessible here.
-        offsets_h
-        syscall_list_h_target
-        driver_validation_h_target
-        kobj_types_h_target
   )
 
-  # Command to generate the rust docs.  As mentioned above, the whole environment is duplicated, so
-  # it is important to keep this in sync with the above.
-  add_custom_command(
+  # Command to generate the rust docs.
+  add_cargo_target_with_zephyr_env(rustdoc
     OUTPUT generate_rust_docs
-    USES_TERMINAL
-    COMMAND
-      ${CMAKE_COMMAND} -E
-      env BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
-      ZEPHYR_BASE=${ZEPHYR_BASE}
-      DOTCONFIG=${DOTCONFIG}
-      ZEPHYR_DTS=${ZEPHYR_DTS}
-      INCLUDE_DIRS="${include_dirs}"
-      INCLUDE_DEFINES="${include_defines}"
-      WRAPPER_FILE="${WRAPPER_FILE}"
-      DT_AUGMENTS="${DT_AUGMENTS}"
-      BINARY_DIR_INCLUDE_GENERATED="${BINARY_DIR_INCLUDE_GENERATED}"
-      cargo doc
-      ${rust_build_type_arg}
-
-      # Override the features according to the shield given. For a general case,
-      # this will need to come from a variable or argument.
-      # TODO: This needs to be passed in.
-      # --no-default-features
-      # --features ${SHIELD_FEATURE}
-
-      # Set a replacement so that packages can just use `zephyr-sys` as a package
-      # name to find it.
-      ${command_paths}
-      --target ${RUST_TARGET}
-      --target-dir ${CARGO_TARGET_DIR}
+    CARGO_ARGS doc
     COMMENT "Building Rust documentation"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  )
-
-  add_custom_target(rustdoc
-    DEPENDS generate_rust_docs
-        # The variables, defined at the top level, don't seem to be accessible here.
-        offsets_h
-        syscall_list_h_target
-        driver_validation_h_target
-        kobj_types_h_target
   )
 
   # Linking with the <rt_library> (`$<TARGET_PROPERTY:linker,rt_library>`).

--- a/ci-manifest.yml
+++ b/ci-manifest.yml
@@ -21,4 +21,5 @@ manifest:
           - cmsis_6    # required by the ARM port
           - hal_nxp    # required by NXP boards (e.g. frdm_mcxa156)
           - hal_nordic # required by the custom_plank board (Nordic based)
+          - hal_rpi_pico # required by Raspberry Pi Pico boards
           - hal_stm32  # required by the nucleo_f302r8 board (STM32 based)

--- a/samples/bench/src/executor.rs
+++ b/samples/bench/src/executor.rs
@@ -236,17 +236,16 @@ async fn high_worker(this: &'static AsyncTests, command: Command) {
 /// which is in the same executor, or with the higher or lower priority worker.
 #[embassy_executor::task(pool_size = NUM_THREADS)]
 async fn worker(this: &'static AsyncTests, command: Command, id: usize) {
-    let total;
-    match command {
-        Command::Empty => total = 1,
-        Command::SimpleSem(count) => total = this.simple_sem(id, count).await,
-        Command::SimpleSemYield(count) => total = this.simple_sem_yield(id, count).await,
-        Command::SemWait(count) => total = this.sem_wait_taker(id, count).await,
-        Command::SemWaitSame(count) => total = this.sem_wait_taker(id, count).await,
-        Command::SemPingPong(count) => total = this.sem_ping_pong_taker(count).await,
-        Command::SemOnePingPong(count) => total = this.sem_ping_pong_taker(count).await,
+    let total = match command {
+        Command::Empty => 1,
+        Command::SimpleSem(count) => this.simple_sem(id, count).await,
+        Command::SimpleSemYield(count) => this.simple_sem_yield(id, count).await,
+        Command::SemWait(count) => this.sem_wait_taker(id, count).await,
+        Command::SemWaitSame(count) => this.sem_wait_taker(id, count).await,
+        Command::SemPingPong(count) => this.sem_ping_pong_taker(count).await,
+        Command::SemOnePingPong(count) => this.sem_ping_pong_taker(count).await,
         command => panic!("Not implemented: {:?}", command),
-    }
+    };
 
     this.results
         .send(TestResult::Worker { id, count: total })

--- a/samples/bench/src/lib.rs
+++ b/samples/bench/src/lib.rs
@@ -262,11 +262,11 @@ impl ThreadTests {
         let mut msg_count = (2 + results.len()) as isize;
 
         // Order is important here, start with the highest priority things.
-        self.high_command.send(command.clone()).unwrap();
+        self.high_command.send(command).unwrap();
         for cmd in &self.commands {
-            cmd.send(command.clone()).unwrap();
+            cmd.send(command).unwrap();
         }
-        self.low_command.send(command.clone()).unwrap();
+        self.low_command.send(command).unwrap();
 
         while let Ok(cmd) = self.results.receiver.recv() {
             match cmd {
@@ -386,6 +386,7 @@ impl ThreadTests {
             sem.give();
             sem.take(NoWait).unwrap();
             *total += 1;
+            // SAFETY: FIXME: To be clarified
             unsafe { k_yield() };
         }
     }
@@ -401,18 +402,13 @@ impl ThreadTests {
     /// Worker side of the ping pong sem, takes the 'sem' and gives to the back_sem.
     fn ping_pong_worker(
         &self,
-        id: usize,
+        _id: usize,
         sem: &Semaphore,
         back_sem: &Semaphore,
         count: usize,
         total: &mut usize,
     ) {
-        for i in 0..count {
-            if false {
-                if let Ok(_) = sem.take(NoWait) {
-                    panic!("Semaphore was already available: {} loop:{}", id, i);
-                }
-            }
+        for _ in 0..count {
             sem.take(Forever).unwrap();
             back_sem.give();
             *total += 1;
@@ -558,11 +554,7 @@ impl Command {
     /// Determine if this command intents for the "low" worker to be at the same priority as the
     /// main worker.
     pub fn is_same_priority(self) -> bool {
-        match self {
-            Self::SemWaitSame(_) => true,
-            Self::SemOnePingPong(_) => true,
-            _ => false,
-        }
+        matches!(self, Self::SemWaitSame(_) | Self::SemOnePingPong(_))
     }
 }
 
@@ -759,6 +751,7 @@ fn sem_bench() {
 
 // For accurate timing, use the cycle counter.
 fn now() -> u64 {
+    // SAFETY: FIXME: To be clarified
     unsafe { k_cycle_get_64() }
 }
 

--- a/samples/button/src/lib.rs
+++ b/samples/button/src/lib.rs
@@ -87,10 +87,14 @@ async fn led_blinker(mut led: Option<GpioPin>) -> ! {
 async fn button_listener(mut button: GpioPin) -> ! {
     let sender = IO_CHANNEL.sender();
     loop {
+        // SAFETY: There is no concurrent access of this GPIO pin, this task is the only one that
+        // waits on it.
         unsafe {
             button.wait_for_low().await;
         }
         sender.send(IoEvent::ButtonPress).await;
+        // SAFETY: There is no concurrent access of this GPIO pin, this task is the only one that
+        // waits on it.
         unsafe {
             button.wait_for_high().await;
         }
@@ -110,6 +114,8 @@ async fn led_timer() -> ! {
 
 #[no_mangle]
 extern "C" fn rust_main() {
+    // SAFETY: `rust_main` runs once during application startup before any rust tasks
+    // are spawned, so the global logger is initialized before concurrent use.
     unsafe {
         zephyr::set_logger().unwrap();
     }

--- a/samples/embassy/src/lib.rs
+++ b/samples/embassy/src/lib.rs
@@ -39,11 +39,14 @@ const LOW_PRIO: c_int = 5;
 
 #[no_mangle]
 extern "C" fn rust_main() {
+    // SAFETY: `rust_main` runs once during application startup before any rust tasks
+    // are spawned, so the global logger is initialized before concurrent use.
     unsafe {
         zephyr::set_logger().unwrap();
     }
 
     // Set our own priority.
+    // SAFETY: `rust_main` runs in a thread context.
     unsafe {
         raw::k_thread_priority_set(raw::k_current_get(), MAIN_PRIO);
     }
@@ -267,6 +270,7 @@ enum Answer {
 
 // TODO: Put this benchmarking stuff somewhere useful.
 fn now() -> u64 {
+    // SAFETY: FIXME: To be clarified
     unsafe { k_cycle_get_64() }
 }
 

--- a/samples/hello_world/src/lib.rs
+++ b/samples/hello_world/src/lib.rs
@@ -7,6 +7,8 @@ use log::info;
 
 #[no_mangle]
 extern "C" fn rust_main() {
+    // SAFETY: `rust_main` runs once during application startup before any rust tasks
+    // are spawned, so the global logger is initialized before concurrent use.
     unsafe {
         zephyr::set_logger().unwrap();
     }

--- a/tests/drivers/gpio-async/src/lib.rs
+++ b/tests/drivers/gpio-async/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 
 use embassy_time::{Duration, Ticker};
 use zephyr::{
-    device::gpio::{GpioPin, GpioToken},
+    device::gpio::GpioPin,
     embassy::Executor,
     raw::{GPIO_PULL_DOWN, ZR_GPIO_INPUT, ZR_GPIO_OUTPUT_ACTIVE},
 };
@@ -20,6 +20,8 @@ static EXECUTOR_MAIN: StaticCell<Executor> = StaticCell::new();
 
 #[no_mangle]
 extern "C" fn rust_main() {
+    // SAFETY: Called before any logging is done and Rust tasks are started.
+    // This is the Rust entrypoint before other Rust tasks are started.
     unsafe {
         zephyr::set_logger().unwrap();
     }
@@ -37,34 +39,33 @@ async fn main(spawner: Spawner) {
 
     let mut col0 = zephyr::devicetree::labels::col0::get_instance().unwrap();
     let mut row0 = zephyr::devicetree::labels::row0::get_instance().unwrap();
-    let mut gpio_token = unsafe { zephyr::device::gpio::GpioToken::get_instance().unwrap() };
 
-    unsafe {
-        col0.configure(&mut gpio_token, ZR_GPIO_OUTPUT_ACTIVE);
-        col0.set(&mut gpio_token, true);
-        row0.configure(&mut gpio_token, ZR_GPIO_INPUT | GPIO_PULL_DOWN);
-    }
+    col0.configure(ZR_GPIO_OUTPUT_ACTIVE);
+    col0.set(true);
+    row0.configure(ZR_GPIO_INPUT | GPIO_PULL_DOWN);
 
     loop {
-        unsafe { row0.wait_for_high(&mut gpio_token).await };
+        // SAFETY: Depends on which gpio-controller runs the test
+        unsafe { row0.wait_for_high().await };
         // Simple debounce, Wait for 20 consecutive high samples.
-        debounce(&mut row0, &mut gpio_token, true).await;
+        debounce(&mut row0, true).await;
         info!("Pressed");
-        unsafe { row0.wait_for_low(&mut gpio_token).await };
-        debounce(&mut row0, &mut gpio_token, false).await;
+        // SAFETY: Depends on which gpio-controller runs the test
+        unsafe { row0.wait_for_low().await };
+        debounce(&mut row0, false).await;
         info!("Released");
     }
 }
 
 /// Simple debounce.  Scan the gpio periodically, and return when we have 20 consecutive samples of
 /// the intended value.
-async fn debounce(pin: &mut GpioPin, gpio_token: &mut GpioToken, level: bool) {
+async fn debounce(pin: &mut GpioPin, level: bool) {
     let mut count = 0;
     let mut ticker = Ticker::every(Duration::from_millis(1));
     loop {
         ticker.next().await;
 
-        if unsafe { pin.get(gpio_token) } == level {
+        if pin.get() == level {
             count += 1;
 
             if count >= 20 {

--- a/tests/time/src/lib.rs
+++ b/tests/time/src/lib.rs
@@ -16,15 +16,29 @@ extern "C" fn rust_main() {
     printkln!("All tests passed");
 }
 
+fn get_entry(index: usize) -> Option<&'static TimeEntry> {
+    // SAFETY: Time count is a compile time size of the time entry array.
+    if index >= unsafe { time_entry_count() } {
+        None
+    } else {
+        // SAFETY: Retrieves a time entry from a statically defined array,
+        // the index is checked against the count and the pointer to the
+        // entry is considered valid.
+        let entry = unsafe { &*get_time_entry(index) };
+        if entry.name.is_null() {
+            None
+        } else {
+            Some(entry)
+        }
+    }
+}
+
 /// Verify that the conversions are correct.
 fn check_conversions() {
     let mut index = 0;
-    loop {
-        // The entry returns is always valid, so is a valid reference.
-        let entry = unsafe { &*get_time_entry(index) };
-        if entry.name.is_null() {
-            break;
-        }
+    while let Some(entry) = get_entry(index) {
+        // SAFETY: These are static compile time C-strings for every TimeEntry,
+        // the name ptr is verified to be non-null.
         let name = unsafe {
             CStr::from_ptr(entry.name)
                 .to_str()
@@ -54,6 +68,7 @@ fn check_conversions() {
                 let value = Duration::millis_at_least(entry.uvalue as Tick);
                 let value = base + value;
                 let value: Timeout = value.into();
+                // SAFETY: Simple conversion from ms to k_timeout_t.
                 let c_value = unsafe { ms_to_abs_timeout(entry.uvalue) };
                 if c_value.ticks != value.0.ticks {
                     printkln!("Mismatch C: {}, Rust: {}", c_value.ticks, value.0.ticks);
@@ -81,4 +96,5 @@ struct TimeEntry {
 extern "C" {
     fn get_time_entry(index: usize) -> *const TimeEntry;
     fn ms_to_abs_timeout(ms: i64) -> k_timeout_t;
+    fn time_entry_count() -> usize;
 }

--- a/tests/time/src/times.c
+++ b/tests/time/src/times.c
@@ -90,6 +90,11 @@ const struct time_entry *get_time_entry(uintptr_t index)
 	return &time_entries[index];
 }
 
+const size_t time_entry_count(void)
+{
+	return sizeof(time_entries) / sizeof(time_entries[0]);
+}
+
 /* The abs timeout is not constant, so provide this wrapper function.
  */
 const k_timeout_t ms_to_abs_timeout(int64_t ms)


### PR DESCRIPTION
Introduces a clippy cmake target that is added to the cmake 'ALL' set of targets.

Runs clippy for all samples and their platforms in the CI.