### PR TITLE
zephyr-sys: fix undefined __UINTxx_C macros under bindgen

### DIFF
--- a/samples/philosophers/src/lib.rs
+++ b/samples/philosophers/src/lib.rs
@@ -74,7 +74,7 @@ extern "C" fn rust_main() {
 
     printkln!("Pre fork");
 
-    for (i, syncer) in (0..NUM_PHIL).zip(syncers.into_iter()) {
+    for (i, syncer) in (0..NUM_PHIL).zip(syncers) {
         phil_thread(i, syncer, stats).start();
     }
 

--- a/zephyr-sys/wrapper.h
+++ b/zephyr-sys/wrapper.h
@@ -24,6 +24,49 @@
 extern int errno;
 #endif
 
+/*
+ * Pull in <stdint.h> before any Zephyr header. Zephyr's mm.h has file-scope
+ * #if directives that reference CONFIG_SRAM_BASE_ADDRESS, which on some
+ * boards expands via __UINT32_C(...). These underscored variants are normally
+ * provided by the compiler as predefines so that Zephyr's minimal libc
+ * <stdint.h> (which only redirects UINT32_C → __UINT32_C for GCC/clang) works.
+ * Ubuntu's libclang-15 as used by bindgen does not surface those predefines,
+ * so we define them ourselves with #ifndef guards in case a future toolchain
+ * supplies them.
+ */
+#include <stdint.h>
+
+#ifndef __INT8_C
+#define __INT8_C(x)    x
+#endif
+#ifndef __INT16_C
+#define __INT16_C(x)   x
+#endif
+#ifndef __INT32_C
+#define __INT32_C(x)   x
+#endif
+#ifndef __INT64_C
+#define __INT64_C(x)   x ## LL
+#endif
+#ifndef __INTMAX_C
+#define __INTMAX_C(x)  x ## LL
+#endif
+#ifndef __UINT8_C
+#define __UINT8_C(x)   x ## U
+#endif
+#ifndef __UINT16_C
+#define __UINT16_C(x)  x ## U
+#endif
+#ifndef __UINT32_C
+#define __UINT32_C(x)  x ## U
+#endif
+#ifndef __UINT64_C
+#define __UINT64_C(x)  x ## ULL
+#endif
+#ifndef __UINTMAX_C
+#define __UINTMAX_C(x) x ## ULL
+#endif
+
 /* First, make sure we have all of our config settings. */
 #include <zephyr/autoconf.h>
 


### PR DESCRIPTION
## Summary

On Ubuntu with `libclang-15`, bindgen fails to process Zephyr's `kernel/internal/mm.h` because of recently-added file-scope `#if` directives that reference `CONFIG_SRAM_BASE_ADDRESS`. On boards whose `autoconf.h` renders that value via `__UINT32_C(...)`, the preprocessor needs that macro defined before it reaches those `#if`s.

GCC and clang normally emit `__INTxx_C` / `__UINTxx_C` as compiler predefines, and Zephyr's minimal libc `<stdint.h>` relies on that — the public `UINTxx_C(...)` macros are simply redirected to the underscored variants on the GCC/clang branch. The libclang used by bindgen does not expose those predefines to its embedded preprocessor, so the `#if`s in `mm.h` fail with `function-like macro '__UINT32_C' is not defined` and bindgen aborts.

This pulls in `<stdint.h>` at the top of `wrapper.h` and explicitly defines the `__INTxx_C` / `__UINTxx_C` set, guarded with `#ifndef` so that a toolchain which does surface them keeps precedence.

### Background

The triggering upstream change is Zephyr commit `eb805306186` ("sca: Fix undefined behavior during preprocessing"), which moved `mm.h`'s evaluation of those Kconfig values into file-scope `#if`s. Before that, the macros only needed to be valid at the point of use, which happened to work without this shim.

## Test plan

- [x] `west build` on an RP2040-class board (which exercises the `CONFIG_SRAM_BASE_ADDRESS = __UINT32_C(0x20000000)` path) under Ubuntu with the system `libclang-15`
- [x] Existing CI continues to pass on other host/board combinations