### PR TITLE
Upgrade embassy dependencies to current releases

### DIFF
--- a/samples/async-philosophers/Cargo.toml
+++ b/samples/async-philosophers/Cargo.toml
@@ -16,15 +16,15 @@ crate-type = ["staticlib"]
 zephyr = { version = "0.1.0", features = ["time-driver", "executor-zephyr"] }
 static_cell = "2.1"
 
-embassy-executor = { version = "0.7.0", features = ["log", "task-arena-size-2048"] }
-embassy-sync = "0.6.2"
+embassy-executor = { version = "0.10.0", features = ["log"] }
+embassy-sync = "0.8.0"
 
 # For real builds, you should figure out your target's tick rate and set the appropriate feature,
 # like in these examples.  Without this, embassy-time will assume a 1Mhz tick rate, and every time
 # operation will involve a conversion.
-embassy-time = "0.4.0"
-# embassy-time = { version = "0.4.0", features = ["tick-hz-10_000"] }
-# embassy-time = { version = "0.4.0", features = ["tick-hz-100"] }
+embassy-time = "0.5.1"
+# embassy-time = { version = "0.5.1", features = ["tick-hz-10_000"] }
+# embassy-time = { version = "0.5.1", features = ["tick-hz-100"] }
 
 # Dependencies that are used by build.rs.
 [build-dependencies]

--- a/samples/async-philosophers/src/async_sem.rs
+++ b/samples/async-philosophers/src/async_sem.rs
@@ -48,7 +48,7 @@ pub async fn phil(spawner: Spawner, stats_sig: &'static ResultSignal) {
             [&FORKS[i], &FORKS[i + 1]]
         };
 
-        spawner.spawn(one_phil(forks, i, stats.clone())).unwrap();
+        spawner.spawn(one_phil(forks, i, stats.clone()).unwrap());
     }
 
     // Wait for them all to finish.

--- a/samples/async-philosophers/src/lib.rs
+++ b/samples/async-philosophers/src/lib.rs
@@ -31,7 +31,7 @@ extern "C" fn rust_main() {
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(main(spawner)).unwrap();
+        spawner.spawn(main(spawner).unwrap());
     })
 }
 
@@ -44,9 +44,7 @@ static RESULT_SIGNAL: ResultSignal = Signal::new();
 async fn main(spawner: Spawner) -> () {
     // First run the async semaphore based one.
     printkln!("Running 'async-sem' test");
-    spawner
-        .spawn(async_sem::phil(spawner, &RESULT_SIGNAL))
-        .unwrap();
+    spawner.spawn(async_sem::phil(spawner, &RESULT_SIGNAL).unwrap());
 
     let stats = RESULT_SIGNAL.wait().await;
     printkln!("Done with 'async-sem' test");

--- a/samples/bench/Cargo.toml
+++ b/samples/bench/Cargo.toml
@@ -18,12 +18,12 @@ critical-section = "1.1.2"
 heapless = "0.8"
 static_cell = "2.1"
 
-embassy-executor = { version = "0.7.0", features = ["log", "task-arena-size-2048"] }
-embassy-sync = "0.6.2"
-embassy-futures = "0.1.1"
+embassy-executor = { version = "0.10.0", features = ["log"] }
+embassy-sync = "0.8.0"
+embassy-futures = "0.1.2"
 
 # Hard code the tick rate.
-embassy-time = { version = "0.4.0", features = ["tick-hz-10_000"] }
+embassy-time = { version = "0.5.1", features = ["tick-hz-10_000"] }
 
 # Dependencies that are used by build.rs.
 [build-dependencies]

--- a/samples/bench/src/executor.rs
+++ b/samples/bench/src/executor.rs
@@ -96,7 +96,7 @@ impl AsyncTests {
     /// test, and the results are then collected, waiting for everything to finish, and reported.
     pub fn run(&'static self, command: Command) {
         if !self.main_started.load(Ordering::Relaxed) {
-            self.spawners[1].spawn(main_run(self)).unwrap();
+            self.spawners[1].spawn(main_run(self).unwrap());
             self.main_started.store(true, Ordering::Relaxed);
         }
 
@@ -273,19 +273,19 @@ async fn main_run(this: &'static AsyncTests) {
         this.back_sem.set(0);
 
         if true {
-            this.spawners[2].spawn(high_worker(this, command)).unwrap();
+            this.spawners[2].spawn(high_worker(this, command).unwrap());
             if command.is_same_priority() {
-                this.spawners[1].spawn(low_worker(this, command)).unwrap();
+                this.spawners[1].spawn(low_worker(this, command).unwrap());
             } else {
-                this.spawners[0].spawn(low_worker(this, command)).unwrap();
+                this.spawners[0].spawn(low_worker(this, command).unwrap());
             }
         } else {
-            this.spawners[1].spawn(high_worker(this, command)).unwrap();
-            this.spawners[1].spawn(low_worker(this, command)).unwrap();
+            this.spawners[1].spawn(high_worker(this, command).unwrap());
+            this.spawners[1].spawn(low_worker(this, command).unwrap());
         }
 
         for id in 0..ntasks {
-            this.spawners[1].spawn(worker(this, command, id)).unwrap();
+            this.spawners[1].spawn(worker(this, command, id).unwrap());
         }
 
         let mut results: heapless::Vec<Option<usize>, NUM_THREADS> = heapless::Vec::new();

--- a/samples/button/Cargo.toml
+++ b/samples/button/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["staticlib"]
 zephyr = { version = "0.1.0", features = ["time-driver", "executor-zephyr", "async-drivers"] }
 log = "0.4.22"
 static_cell = "2.1"
-embassy-executor = { version = "0.7.0", features = ["log", "task-arena-size-2048"] }
-embassy-sync = "0.6.2"
-embassy-time = { version = "0.4.0", features = ["tick-hz-32_768"] }
+embassy-executor = { version = "0.10.0", features = ["log"] }
+embassy-sync = "0.8.0"
+embassy-time = { version = "0.5.1", features = ["tick-hz-32_768"] }
 
 [build-dependencies]
 zephyr-build = "0.1.0"

--- a/samples/button/src/lib.rs
+++ b/samples/button/src/lib.rs
@@ -123,18 +123,18 @@ extern "C" fn rust_main() {
     executor.run(|spawner| {
         match led0 {
             Ok(led) => {
-                spawner.spawn(led_timer()).unwrap();
-                spawner.spawn(led_blinker(Some(led))).unwrap();
+                spawner.spawn(led_timer().unwrap());
+                spawner.spawn(led_blinker(Some(led)).unwrap());
             }
             Err(e) => {
                 warn!("Failed to configure LED: {}", e);
-                spawner.spawn(led_blinker(None)).unwrap();
+                spawner.spawn(led_blinker(None).unwrap());
             }
         }
 
         match sw0 {
             Ok(button) => {
-                spawner.spawn(button_listener(button)).unwrap();
+                spawner.spawn(button_listener(button).unwrap());
             }
             Err(e) => warn!("Failed to configure button: {}", e),
         }

--- a/samples/embassy/Cargo.toml
+++ b/samples/embassy/Cargo.toml
@@ -19,23 +19,22 @@ static_cell = "2.1"
 heapless = "0.8"
 
 [dependencies.embassy-executor]
-version = "0.7.0"
+version = "0.10.0"
 # path = "../../embassy/embassy-executor"
 features = [
   "log",
-  "task-arena-size-2048",
 ]
 
 [dependencies.embassy-futures]
-version = "0.1.1"
+version = "0.1.2"
 # path = "../../embassy/embassy-futures"
 
 [dependencies.embassy-sync]
-version = "0.6.2"
+version = "0.8.0"
 # path = "../../embassy/embassy-sync"
 
 [dependencies.embassy-time]
-version = "0.4.0"
+version = "0.5.1"
 # path = "../../embassy/embassy-time"
 # This is board specific.
 features = ["tick-hz-10_000"]
@@ -48,7 +47,7 @@ version = "1.2"
 default = ["executor-zephyr"]
 
 executor-thread = [
-  "embassy-executor/arch-cortex-m",
+  "embassy-executor/platform-cortex-m",
   "embassy-executor/executor-thread",
 ]
 

--- a/samples/embassy/src/lib.rs
+++ b/samples/embassy/src/lib.rs
@@ -64,7 +64,7 @@ extern "C" fn rust_main() {
 
     let executor = EXECUTOR_MAIN.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(main(spawner)).unwrap();
+        spawner.spawn(main(spawner).unwrap());
     })
 }
 
@@ -146,13 +146,13 @@ impl ThreadTests {
 
         // Fire off all of the workers.
         for id in 0..self.count {
-            spawner.spawn(worker(self, id, command)).unwrap();
+            spawner.spawn(worker(self, id, command).unwrap());
         }
 
         // And the "low" priority thread (which isn't lower at this time).
-        low_spawner.spawn(low_task(self, command)).unwrap();
+        low_spawner.spawn(low_task(self, command).unwrap());
         //let _ = low_spawner;
-        //spawner.spawn(low_task(self, command)).unwrap();
+        //spawner.spawn(low_task(self, command).unwrap());
 
         // Now wait for all of the responses.
         loop {

--- a/tests/drivers/gpio-async/Cargo.toml
+++ b/tests/drivers/gpio-async/Cargo.toml
@@ -19,20 +19,19 @@ static_cell = "2.1"
 heapless = "0.8"
 
 [dependencies.embassy-executor]
-version = "0.7.0"
+version = "0.10.0"
 features = [
   "log",
-  "task-arena-size-2048",
 ]
 
 [dependencies.embassy-futures]
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies.embassy-sync]
-version = "0.6.2"
+version = "0.8.0"
 
 [dependencies.embassy-time]
-version = "0.4.0"
+version = "0.5.1"
 features = ["tick-hz-10_000"]
 
 [dependencies.critical-section]

--- a/tests/drivers/gpio-async/src/lib.rs
+++ b/tests/drivers/gpio-async/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 
 use embassy_time::{Duration, Ticker};
 use zephyr::{
-    device::gpio::{GpioPin, GpioToken},
+    device::gpio::GpioPin,
     embassy::Executor,
     raw::{GPIO_PULL_DOWN, ZR_GPIO_INPUT, ZR_GPIO_OUTPUT_ACTIVE},
 };
@@ -37,34 +37,31 @@ async fn main(spawner: Spawner) {
 
     let mut col0 = zephyr::devicetree::labels::col0::get_instance().unwrap();
     let mut row0 = zephyr::devicetree::labels::row0::get_instance().unwrap();
-    let mut gpio_token = unsafe { zephyr::device::gpio::GpioToken::get_instance().unwrap() };
 
-    unsafe {
-        col0.configure(&mut gpio_token, ZR_GPIO_OUTPUT_ACTIVE);
-        col0.set(&mut gpio_token, true);
-        row0.configure(&mut gpio_token, ZR_GPIO_INPUT | GPIO_PULL_DOWN);
-    }
+    col0.configure(ZR_GPIO_OUTPUT_ACTIVE);
+    col0.set(true);
+    row0.configure(ZR_GPIO_INPUT | GPIO_PULL_DOWN);
 
     loop {
-        unsafe { row0.wait_for_high(&mut gpio_token).await };
+        unsafe { row0.wait_for_high().await };
         // Simple debounce, Wait for 20 consecutive high samples.
-        debounce(&mut row0, &mut gpio_token, true).await;
+        debounce(&mut row0, true).await;
         info!("Pressed");
-        unsafe { row0.wait_for_low(&mut gpio_token).await };
-        debounce(&mut row0, &mut gpio_token, false).await;
+        unsafe { row0.wait_for_low().await };
+        debounce(&mut row0, false).await;
         info!("Released");
     }
 }
 
 /// Simple debounce.  Scan the gpio periodically, and return when we have 20 consecutive samples of
 /// the intended value.
-async fn debounce(pin: &mut GpioPin, gpio_token: &mut GpioToken, level: bool) {
+async fn debounce(pin: &mut GpioPin, level: bool) {
     let mut count = 0;
     let mut ticker = Ticker::every(Duration::from_millis(1));
     loop {
         ticker.next().await;
 
-        if unsafe { pin.get(gpio_token) } == level {
+        if pin.get() == level {
             count += 1;
 
             if count >= 20 {

--- a/tests/drivers/gpio-async/src/lib.rs
+++ b/tests/drivers/gpio-async/src/lib.rs
@@ -26,7 +26,7 @@ extern "C" fn rust_main() {
 
     let executor = EXECUTOR_MAIN.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(main(spawner)).unwrap();
+        spawner.spawn(main(spawner).unwrap());
     })
 }
 

--- a/zephyr-sys/wrapper.h
+++ b/zephyr-sys/wrapper.h
@@ -24,6 +24,49 @@
 extern int errno;
 #endif
 
+/*
+ * Pull in <stdint.h> before any Zephyr header. Zephyr's mm.h has file-scope
+ * #if directives that reference CONFIG_SRAM_BASE_ADDRESS, which on some
+ * boards expands via __UINT32_C(...). These underscored variants are normally
+ * provided by the compiler as predefines so that Zephyr's minimal libc
+ * <stdint.h> (which only redirects UINT32_C → __UINT32_C for GCC/clang) works.
+ * Ubuntu's libclang-15 as used by bindgen does not surface those predefines,
+ * so we define them ourselves with #ifndef guards in case a future toolchain
+ * supplies them.
+ */
+#include <stdint.h>
+
+#ifndef __INT8_C
+#define __INT8_C(x)    x
+#endif
+#ifndef __INT16_C
+#define __INT16_C(x)   x
+#endif
+#ifndef __INT32_C
+#define __INT32_C(x)   x
+#endif
+#ifndef __INT64_C
+#define __INT64_C(x)   x ## LL
+#endif
+#ifndef __INTMAX_C
+#define __INTMAX_C(x)  x ## LL
+#endif
+#ifndef __UINT8_C
+#define __UINT8_C(x)   x ## U
+#endif
+#ifndef __UINT16_C
+#define __UINT16_C(x)  x ## U
+#endif
+#ifndef __UINT32_C
+#define __UINT32_C(x)  x ## U
+#endif
+#ifndef __UINT64_C
+#define __UINT64_C(x)  x ## ULL
+#endif
+#ifndef __UINTMAX_C
+#define __UINTMAX_C(x) x ## ULL
+#endif
+
 /* First, make sure we have all of our config settings. */
 #include <zephyr/autoconf.h>
 

--- a/zephyr/Cargo.toml
+++ b/zephyr/Cargo.toml
@@ -56,15 +56,15 @@ version = "0.2"
 optional = true
 
 [dependencies.embassy-time-queue-utils]
-version = "0.1"
+version = "0.3"
 optional = true
 
 [dependencies.embassy-sync]
-version = "0.6.2"
+version = "0.8.0"
 optional = true
 
 [dependencies.embassy-executor]
-version = "0.7.0"
+version = "0.10.0"
 optional = true
 
 # These are needed at build time.


### PR DESCRIPTION
Bump the embassy crates used by the zephyr crate, samples, and tests
to their latest releases:

| crate | from | to |
| ----- | ---- | -- |
| embassy-executor | 0.7.0 | 0.10.0 |
| embassy-sync | 0.6.2 | 0.8.0 |
| embassy-time | 0.4.0 | 0.5.1 |
| embassy-futures | 0.1.1 | 0.1.2 |
| embassy-time-queue-utils | 0.1 | 0.3 |

Breaking changes handled:

- embassy-executor 0.8 removed the `task-arena-size-*` features (task
  pools are now statically allocated on stable Rust); dropped from the
  affected manifests.
- The executor `arch-*` features were renamed to `platform-*`; the
  embassy sample's `executor-thread` feature now selects
  `platform-cortex-m`.
- `#[embassy_executor::task]` functions now return
  `Result<SpawnToken, SpawnError>` and `Spawner::spawn` returns `()`,
  so each `.unwrap()` moves from the spawn call onto the task-function
  call.

The zephyr crate's own embassy glue (time driver, executor, gpio waker)
needs no source changes; the integrated timer queue now routes through
the new embassy-executor-timer-queue crate transitively.

Built and linked for the embassy samples/tests: samples/embassy,
samples/button, samples/bench, samples/async-philosophers on tiny2040;
tests/drivers/gpio-async on rpi_pico.

Stacked on #160 (base `davidb-gpio-async-token`); GitHub will retarget
this to `main` once that merges.
