### PR TITLE
ci: trigger build and docs on davidb-* PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ on:
     branches:
       - main
       - v*-branch
+      - davidb-*
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,8 @@ name: Generate and Preview Rust Docs
 on:
   pull_request:
     branches:
-      - main  # Only generate docs for PRs targeting main
+      - main
+      - davidb-*
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

The stacked-PR workflow uses `davidb-`-prefixed branches as bases for in-progress work. Without this trigger, only PRs targeting `main` get build and docs CI feedback, leaving the downstream PRs in the stack without per-push validation.

Limit the new trigger to `davidb-*` (not all branches) so unrelated refs don't incur expensive CI runs.

## Test plan

- [x] Verify YAML still parses (workflow files validated on push).
- [ ] After merge, rebase the existing stack (#146 → #148 → #149 → #150) onto this so each PR's base branch carries the new trigger, then confirm CI fires.