### PR TITLE
samples: Fix various clippy errors

### DIFF
--- a/samples/blinky/sample.yaml
+++ b/samples/blinky/sample.yaml
@@ -4,11 +4,12 @@ sample:
 common:
   filter: CONFIG_RUST_SUPPORTED
   platform_allow:
-    - qemu_cortex_m0
-    - qemu_cortex_m3
-    - qemu_riscv32
-    - qemu_riscv64
-    - nrf52840dk/nrf52840
+    # - qemu_cortex_m0
+    # - qemu_cortex_m3
+    # - qemu_riscv32
+    # - qemu_riscv64
+    # - nrf52840dk/nrf52840
+    - nrf5340dk/nrf5340/cpuapp
 tests:
   sample.rust.basic.blinky:
     tags:

--- a/samples/blinky/src/lib.rs
+++ b/samples/blinky/src/lib.rs
@@ -9,9 +9,12 @@
 #![allow(unexpected_cfgs)]
 
 use log::warn;
+use zephyr::time::{sleep, Forever};
 
 #[no_mangle]
 extern "C" fn rust_main() {
+    // SAFETY: `rust_main` runs once during application startup before any rust tasks
+    // are spawned, so the global logger is initialized before concurrent use.
     unsafe {
         zephyr::set_logger().unwrap();
     }
@@ -24,7 +27,7 @@ extern "C" fn rust_main() {
 #[cfg(dt = "aliases::led0")]
 fn do_blink() {
     use zephyr::raw::ZR_GPIO_OUTPUT_ACTIVE;
-    use zephyr::time::{sleep, Duration};
+    use zephyr::time::Duration;
 
     warn!("Inside of blinky");
 
@@ -32,7 +35,7 @@ fn do_blink() {
 
     if !led0.is_ready() {
         warn!("LED is not ready");
-        loop {}
+        sleep(Forever);
     }
 
     led0.configure(ZR_GPIO_OUTPUT_ACTIVE);
@@ -46,5 +49,5 @@ fn do_blink() {
 #[cfg(not(dt = "aliases::led0"))]
 fn do_blink() {
     warn!("No leds configured");
-    loop {}
+    sleep(Forever);
 }

--- a/samples/button/src/lib.rs
+++ b/samples/button/src/lib.rs
@@ -11,9 +11,7 @@
 use log::{debug, info, warn};
 
 use zephyr::device::gpio::GpioPin;
-use zephyr::devicetree;
 use zephyr::embassy::Executor;
-use zephyr::raw::{ZR_GPIO_INPUT, ZR_GPIO_OUTPUT_ACTIVE};
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
@@ -149,12 +147,12 @@ extern "C" fn rust_main() {
 
 #[cfg(dt = "aliases::sw0")]
 fn configure_button() -> Result<GpioPin, &'static str> {
-    let mut sw0 = devicetree::aliases::sw0::get_instance().unwrap();
+    let mut sw0 = zephyr::devicetree::aliases::sw0::get_instance().unwrap();
 
     if !sw0.is_ready() {
         Err("Button is not ready")
     } else {
-        sw0.configure(ZR_GPIO_INPUT);
+        sw0.configure(zephyr::raw::ZR_GPIO_INPUT);
         Ok(sw0)
     }
 }
@@ -166,12 +164,12 @@ fn configure_button() -> Result<GpioPin, &'static str> {
 
 #[cfg(dt = "aliases::led0")]
 fn configure_led() -> Result<GpioPin, &'static str> {
-    let mut led0 = devicetree::aliases::led0::get_instance().unwrap();
+    let mut led0 = zephyr::devicetree::aliases::led0::get_instance().unwrap();
 
     if !led0.is_ready() {
         Err("LED is not ready")
     } else {
-        led0.configure(ZR_GPIO_OUTPUT_ACTIVE);
+        led0.configure(zephyr::raw::ZR_GPIO_OUTPUT_ACTIVE);
         Ok(led0)
     }
 }


### PR DESCRIPTION
The blinky sample currently won't build at all (regardless of platform) due to clippy errors present, so we fix those.

The button sample currently won't build on platforms (such as qemu_riscv32) that don't support led0, but since the sample has runtime error reporting for this case I assume we do still want it to build, so fix those as well.

Lastly, the broken blinky sample seems to have made it through CI (even though CI does a clippy check on all samples) because of its sample.yaml file containing some qemu boards which are chosen as the single 'default' by the twister job in build.yml, but gets filtered out by its own filter property in sample.yaml. For this I just mirrored the button's sample.yaml, but maybe revisiting the clippy check in CI is a better approach.