### PR TITLE
zephyr-panic: Move panic handler into crate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ function(rust_cargo_application)
   # For now, hard-code the Zephyr crate directly here.  Once we have
   # more than one crate, these should be added by the modules
   # themselves.
-  set(LIB_RUST_CRATES zephyr zephyr-build zephyr-sys)
+  set(LIB_RUST_CRATES zephyr zephyr-build zephyr-sys zephyr-panic)
 
   get_include_dirs(zephyr_interface include_dirs)
 

--- a/docgen/Cargo.toml
+++ b/docgen/Cargo.toml
@@ -14,3 +14,4 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = { version = "0.1.0", features = ["executor-zephyr", "async-drivers"] }
+zephyr-panic = "0.1.0"

--- a/docgen/src/lib.rs
+++ b/docgen/src/lib.rs
@@ -5,9 +5,8 @@
 
 use zephyr::printkln;
 
-// Reference the Zephyr crate so that the panic handler gets used.  This is only needed if no
-// symbols from the crate are directly used.
-extern crate zephyr;
+// Bring in the Zephyr panic handler.
+use zephyr_panic as _;
 
 #[no_mangle]
 extern "C" fn rust_main() {

--- a/samples/async-philosophers/Cargo.toml
+++ b/samples/async-philosophers/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = { version = "0.1.0", features = ["time-driver", "executor-zephyr"] }
+zephyr-panic = "0.1.0"
 static_cell = "2.1"
 
 embassy-executor = { version = "0.7.0", features = ["log", "task-arena-size-2048"] }

--- a/samples/async-philosophers/src/lib.rs
+++ b/samples/async-philosophers/src/lib.rs
@@ -14,6 +14,7 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex, s
 use embassy_time::Duration;
 use static_cell::StaticCell;
 use zephyr::{embassy::Executor, printkln, sync::Arc, sys::uptime_get};
+use zephyr_panic as _;
 
 mod async_sem;
 

--- a/samples/bench/Cargo.toml
+++ b/samples/bench/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = { version = "0.1.0", features = ["time-driver", "executor-zephyr"] }
+zephyr-panic = "0.1.0"
 critical-section = "1.1.2"
 heapless = "0.8"
 static_cell = "2.1"

--- a/samples/bench/src/lib.rs
+++ b/samples/bench/src/lib.rs
@@ -33,6 +33,7 @@ use zephyr::{
     time::Forever,
     work::WorkQueue,
 };
+use zephyr_panic as _;
 
 mod executor;
 

--- a/samples/blinky/Cargo.toml
+++ b/samples/blinky/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = "0.1.0"
+zephyr-panic = "0.1.0"
 log = "0.4.22"
 
 [build-dependencies]

--- a/samples/blinky/src/lib.rs
+++ b/samples/blinky/src/lib.rs
@@ -10,6 +10,8 @@
 
 use log::warn;
 
+use zephyr_panic as _;
+
 #[no_mangle]
 extern "C" fn rust_main() {
     unsafe {

--- a/samples/button/Cargo.toml
+++ b/samples/button/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = { version = "0.1.0", features = ["time-driver", "executor-zephyr", "async-drivers"] }
+zephyr-panic = "0.1.0"
 log = "0.4.22"
 static_cell = "2.1"
 embassy-executor = { version = "0.7.0", features = ["log", "task-arena-size-2048"] }

--- a/samples/button/src/lib.rs
+++ b/samples/button/src/lib.rs
@@ -14,6 +14,7 @@ use zephyr::device::gpio::GpioPin;
 use zephyr::devicetree;
 use zephyr::embassy::Executor;
 use zephyr::raw::{ZR_GPIO_INPUT, ZR_GPIO_OUTPUT_ACTIVE};
+use zephyr_panic as _;
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;

--- a/samples/embassy/Cargo.toml
+++ b/samples/embassy/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = { version = "0.1.0", features = ["time-driver"] }
+zephyr-panic = "0.1.0"
 log = "0.4.22"
 static_cell = "2.1"
 heapless = "0.8"

--- a/samples/embassy/src/lib.rs
+++ b/samples/embassy/src/lib.rs
@@ -7,6 +7,8 @@ extern crate alloc;
 
 use core::ffi::c_int;
 
+use zephyr_panic as _;
+
 #[cfg(feature = "executor-thread")]
 use embassy_executor::Executor;
 

--- a/samples/hello_world/Cargo.toml
+++ b/samples/hello_world/Cargo.toml
@@ -14,4 +14,5 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = "0.1.0"
+zephyr-panic = "0.1.0"
 log = "0.4.22"

--- a/samples/hello_world/src/lib.rs
+++ b/samples/hello_world/src/lib.rs
@@ -5,6 +5,8 @@
 
 use log::info;
 
+use zephyr_panic as _;
+
 #[no_mangle]
 extern "C" fn rust_main() {
     // SAFETY: `rust_main` runs once during application startup before any rust tasks

--- a/samples/philosophers/Cargo.toml
+++ b/samples/philosophers/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = "0.1.0"
+zephyr-panic = "0.1.0"
 
 # Dependencies that are used by build.rs.
 [build-dependencies]

--- a/samples/philosophers/src/lib.rs
+++ b/samples/philosophers/src/lib.rs
@@ -9,6 +9,8 @@
 
 extern crate alloc;
 
+use zephyr_panic as _;
+
 #[allow(unused_imports)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;

--- a/tests/drivers/gpio-async/Cargo.toml
+++ b/tests/drivers/gpio-async/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = { version = "0.1.0", features = ["time-driver", "executor-zephyr", "async-drivers"] }
+zephyr-panic = "0.1.0"
 log = "0.4.22"
 static_cell = "2.1"
 heapless = "0.8"

--- a/tests/drivers/gpio-async/src/lib.rs
+++ b/tests/drivers/gpio-async/src/lib.rs
@@ -11,6 +11,7 @@ use zephyr::{
     embassy::Executor,
     raw::{GPIO_PULL_DOWN, ZR_GPIO_INPUT, ZR_GPIO_OUTPUT_ACTIVE},
 };
+use zephyr_panic as _;
 
 use embassy_executor::Spawner;
 use log::info;

--- a/tests/time/Cargo.toml
+++ b/tests/time/Cargo.toml
@@ -14,3 +14,4 @@ crate-type = ["staticlib"]
 
 [dependencies]
 zephyr = "0.1.0"
+zephyr-panic = "0.1.0"

--- a/tests/time/src/lib.rs
+++ b/tests/time/src/lib.rs
@@ -8,6 +8,7 @@ use core::ffi::{c_char, CStr};
 use zephyr::printkln;
 use zephyr::raw::k_timeout_t;
 use zephyr::time::{Duration, Instant, Tick, Timeout};
+use zephyr_panic as _;
 
 #[no_mangle]
 extern "C" fn rust_main() {

--- a/tests/timer/Cargo.toml
+++ b/tests/timer/Cargo.toml
@@ -16,3 +16,4 @@ crate-type = ["staticlib"]
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false }
 zephyr = "0.1.0"
+zephyr-panic = "0.1.0"

--- a/tests/timer/src/lib.rs
+++ b/tests/timer/src/lib.rs
@@ -16,6 +16,7 @@ use zephyr::{
     time::{Duration, NoWait, Tick},
     timer::{Callback, CallbackTimer, SimpleTimer, StoppedTimer},
 };
+use zephyr_panic as _;
 
 // Test the timers interface.  There are a couple of things this tries to test:
 // 1. Do timers dynamically allocated and dropped work.

--- a/zephyr-panic/Cargo.toml
+++ b/zephyr-panic/Cargo.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 Open Device Partnership and Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "zephyr-panic"
+version = "0.1.0"
+edition = "2021"
+description = """
+Panic handler for Rust-based applications that run on Zephyr.
+"""
+
+[dependencies]
+zephyr = { version = "0.1.0", path = "../zephyr" }
+
+[build-dependencies]
+zephyr-build = { version = "0.1.0", path = "../zephyr-build" }

--- a/zephyr-panic/build.rs
+++ b/zephyr-panic/build.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Open Device Partnership and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Pre-build code for the zephyr-panic module.
+
+// This makes the values from the generated .config available as conditional compilation, so that
+// the panic handler can optionally print using `printk` when it is configured into the build.
+
+fn main() {
+    zephyr_build::export_kconfig_bool_options();
+}

--- a/zephyr-panic/src/lib.rs
+++ b/zephyr-panic/src/lib.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Open Device Partnership and Contributors
+// Copyright (c) 2024 Linaro LTD
+// SPDX-License-Identifier: Apache-2.0
+
+//! Set the panicking behavior to log over printk if CONFIG_PRINTK is set,
+//! then call the system panic function.
+//!
+//! This is intended to only be used by Rust applications that run on Zephyr,
+//! not for general Rust applications.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! #![no_std]
+//!
+//! use zephyr_panic as _;
+//!
+//! #[no_mangle]
+//! extern "C" fn rust_main() {
+//!     panic!("Message is logged if CONFIG_PRINTK is set, then system panic function is called.");
+//! }
+//! ```
+#![no_std]
+#![allow(unexpected_cfgs)]
+
+use core::panic::PanicInfo;
+
+/// Override rust's panic.  This simplistic initial version just hangs in a loop.
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    #[cfg(CONFIG_PRINTK)]
+    {
+        zephyr::printkln!("panic: {}", info);
+    }
+    let _ = info;
+
+    // Call into the wrapper for the system panic function.
+    unsafe {
+        extern "C" {
+            fn rust_panic_wrap() -> !;
+        }
+        rust_panic_wrap();
+    }
+}

--- a/zephyr/src/lib.rs
+++ b/zephyr/src/lib.rs
@@ -138,26 +138,6 @@ compile_error!("CONFIG_RUST must be set to build Rust in Zephyr");
 #[cfg(CONFIG_PRINTK)]
 pub mod printk;
 
-use core::panic::PanicInfo;
-
-/// Override rust's panic.  This simplistic initial version just hangs in a loop.
-#[panic_handler]
-fn panic(info: &PanicInfo) -> ! {
-    #[cfg(CONFIG_PRINTK)]
-    {
-        printkln!("panic: {}", info);
-    }
-    let _ = info;
-
-    // Call into the wrapper for the system panic function.
-    unsafe {
-        extern "C" {
-            fn rust_panic_wrap() -> !;
-        }
-        rust_panic_wrap();
-    }
-}
-
 /// Re-export of zephyr-sys as `zephyr::raw`.
 pub mod raw {
     pub use zephyr_sys::*;


### PR DESCRIPTION
Currently the zephyr crate defines a panic handler implementation, forcing all downstream users into that specific implementation. Ideally users should be able to use the zephyr crate as a library while still having a choice in which panic handler is used. So, the panic handler has been moved into a separate zephyr-panic crate allowing users to opt-in.

One motivation, for example, is the fact that all the metadata associated with panics can significantly bloat binary size. If a user doesn't want to log the panic info or care about it in any way, they can instead choose to use the `panic-halt` crate which allows the compiler to optimize all that out as dead code.

Couple notes:
- I had also considered keeping the panic handler in the `zephyr` crate and making it opt-in via a feature flag, but this just didn't feel right. I think the top-level application code should always explicitly choose a panic handler implementation. This matches the existing panic handling crate ecosystem where you typically see `use panic_halt as _`, `use panic_rtt as _`, etc. Additionally, the feature flag approach leads to the possibility that application code could pull in the zephyr crate transitively from a dep that enables the panic handler, leading to confusion.
- More of a cosmetic issue, but I wanted to name the crate `panic-zephyr` to match the format of other panic crates, but instead chose `zephyr-panic` to keep the name consistent with the other crates in this repo.
- This change was a bit invasive in that I had to modify all the samples/test code (making up the bulk of this PR, although it's just a couple lines changed per sample). This is also a breaking change in that downstream users now need to explicitly opt-in to the panic handler (just like the samples do) while previously it was always included by default.