### PR TITLE
zephyr: blocking: Desugar async `run` and reword doc comment

### DIFF
--- a/zephyr/src/blocking.rs
+++ b/zephyr/src/blocking.rs
@@ -124,7 +124,7 @@ enum SlotState {
 struct Slot {
     /// Reserved for `k_queue`'s linkage while enqueued.
     _link: UnsafeCell<usize>,
-    /// Serializes access to the future's [`Shared`] state.
+    /// Keeps the future alive while a worker is using its memory.
     lock: SpinMutex<()>,
     /// The current [`SlotState`].
     state: AtomicU8,

--- a/zephyr/src/blocking.rs
+++ b/zephyr/src/blocking.rs
@@ -85,7 +85,7 @@ static SLOT_POOL: SlotPool = SlotPool::new();
 /// However, if a worker thread has already picked up the operation and begun executing it,
 /// canceling will **NOT** stop the blocking operation. It will still run to completion,
 /// but its result is simply discarded. Any side effects of the operation will still be seen.
-pub async fn run<F, R>(op: F) -> R
+pub fn run<F, R>(op: F) -> impl Future<Output = R>
 where
     F: FnOnce() -> R + Send + 'static,
     R: Send + 'static,
@@ -98,7 +98,6 @@ where
         slot: None,
         _pin: PhantomPinned,
     }
-    .await
 }
 
 /// [`Slot`] state, stored internally in an `AtomicU8`.


### PR DESCRIPTION
This just addresses a couple minor reviews from #173.

Fist commit desugars the async `run` function to help reduce binary size. Confirmed this is the case, building the `blocking` sample with the desugared `run` reduced binary size by about 100 bytes, and would likely scale the more the function is called.

Second commit just changes the doc comment for the `Slot::lock` field to make it clearer what it's doing (it's mainly there to stop a potential race where the future might drop while the worker thread is still briefly accessing parts of shared memory, e.g. moving the closure from the future into its own memory, so the lock ensures the future will block very briefly before dropping in this case).